### PR TITLE
Fix: Remove console.log statements from production JavaScript

### DIFF
--- a/admin/js/activation-wizard.js
+++ b/admin/js/activation-wizard.js
@@ -44,7 +44,6 @@
 				},
 				success: function (response) {
 					if (response.success) {
-						console.log('Startup credits ensured for user.');
 					}
 				},
 				error: function () {
@@ -535,7 +534,6 @@
 					prompt_id: this.postData.prompt_id,
 				},
 				success: function () {
-					console.log('Weekly enabled.');
 				},
 				error: function () {
 					console.error('Failed to enable weekly.');

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -681,7 +681,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
             })
             .then(data => {
-                console.log('Publishing response:', data); // Debug log
                 
                 if (data.success) {
                     // Show success message

--- a/admin/js/block-editor-integration.js
+++ b/admin/js/block-editor-integration.js
@@ -305,7 +305,6 @@
             render: AIContentEditorPanel,
             icon: 'edit',
         });
-        console.log('AI Content Editor: Plugin registered successfully');
     } catch (error) {
         console.error('AI Content Editor: Failed to register plugin:', error);
     }

--- a/admin/js/content-editor.js
+++ b/admin/js/content-editor.js
@@ -23,7 +23,6 @@
      * Initialize the content editor
      */
     function initContentEditor() {
-        console.log('AI Content Editor: Initializing for', aistmaContentEditor.editorType, 'editor');
 
         if (aistmaContentEditor.editorType === 'classic') {
             initClassicEditor();
@@ -68,7 +67,6 @@
             setTimeout(handleTextSelection, 100);
         });
 
-        console.log('AI Content Editor: TinyMCE integration setup complete');
     }
 
     /**
@@ -76,7 +74,6 @@
      */
     function initBlockEditor() {
         // Block editor integration is handled by block-editor-integration.js
-        console.log('AI Content Editor: Block editor integration will be handled by dedicated script');
     }
 
     /**
@@ -293,7 +290,6 @@
      */
     function applyToBlockEditor() {
         // Block editor integration is handled by block-editor-integration.js
-        console.log('Block editor apply will be handled by dedicated script');
     }
 
     /**
@@ -398,7 +394,6 @@
     function showUsageInfo(usageInfo) {
         if (usageInfo.daily_limit > 0) {
             const message = `Usage: ${usageInfo.used_today}/${usageInfo.daily_limit} operations today`;
-            console.log('AI Content Editor:', message);
         }
     }
 


### PR DESCRIPTION
Removes 9 debug console.log statements from JavaScript files.

## Files Updated
- admin/js/content-editor.js (5 statements)
- admin/js/activation-wizard.js (2 statements)
- admin/js/admin.js (1 statement)
- admin/js/block-editor-integration.js (1 statement)

## Why
Debug console.log statements in production can:
- Expose sensitive information
- Impact performance
- Violate WordPress standards

Closes #110