### PR TITLE
Fix: Replace deprecated current_time('timestamp') with time()

### DIFF
--- a/admin/widgets/data-cards-widget.php
+++ b/admin/widgets/data-cards-widget.php
@@ -226,7 +226,7 @@ class AISTMA_Data_Cards_Widget {
 						</a>
 						<span class="post-date">
 							<?php if ( $post_date ) : ?>
-								<?php echo esc_html( human_time_diff( strtotime( $post_date ), current_time( 'timestamp' ) ) ); ?> 
+								<?php echo esc_html( human_time_diff( strtotime( $post_date ), time() ) ); ?> 
 								<?php esc_html_e( 'ago', 'ai-story-maker' ); ?>
 							<?php endif; ?>
 						</span>

--- a/includes/class-aistma-activation-wizard.php
+++ b/includes/class-aistma-activation-wizard.php
@@ -50,7 +50,7 @@ class AISTMA_Activation_Wizard {
 		$last_shown = get_user_meta( $user_id, self::WIZARD_LAST_SHOWN_KEY, true );
 		if ( ! empty( $last_shown ) ) {
 			$last_shown_time = strtotime( $last_shown );
-			$current_time = current_time( 'timestamp' );
+			$current_time = time();
 			$hours_elapsed = ( $current_time - $last_shown_time ) / 3600;
 
 			// If less than 24 hours have passed, don't show

--- a/includes/class-aistma-rating-request.php
+++ b/includes/class-aistma-rating-request.php
@@ -67,7 +67,7 @@ class AISTMA_Rating_Request {
 	 */
 	public static function mark_rating_shown( $user_id ) {
 		$user_id = absint( $user_id );
-		update_user_meta( $user_id, self::META_KEY_RATING_SHOWN, current_time( 'timestamp' ) );
+		update_user_meta( $user_id, self::META_KEY_RATING_SHOWN, time() );
 	}
 
 	/**
@@ -104,7 +104,7 @@ class AISTMA_Rating_Request {
 
 		// Check cooldown (7 days)
 		$last_shown_timestamp = absint( $last_shown );
-		$days_since = floor( ( current_time( 'timestamp' ) - $last_shown_timestamp ) / DAY_IN_SECONDS );
+		$days_since = floor( ( time() - $last_shown_timestamp ) / DAY_IN_SECONDS );
 
 		return $days_since >= self::REMINDER_COOLDOWN_DAYS;
 	}


### PR DESCRIPTION
Replaces 4 instances of deprecated current_time('timestamp') with time().

## Why
- current_time('timestamp') deprecated in WordPress 5.3
- Plugin requires WordPress 5.8+
- Improves code quality and WP standards compliance

## Files Updated
- admin/widgets/data-cards-widget.php (1)
- includes/class-aistma-rating-request.php (2)
- includes/class-aistma-activation-wizard.php (1)

Closes #108