### PR TITLE
Fix: Catch correct Exception class namespace

### DIFF
--- a/includes/class-aistma-story-generator.php
+++ b/includes/class-aistma-story-generator.php
@@ -822,7 +822,7 @@ class AISTMA_Story_Generator {
 					$this->aistma_log_manager->log( 'error', 'Error fetching dynamic instructions: ' . $api_response->get_error_message() );
 					$aistma_master_instructions = '';
 				}
-			} catch ( Exception $e ) {
+			} catch ( \Exception $e ) {
 				// Silent fail; fallback will be handled below.
 				$this->aistma_log_manager->log( 'error', 'Error fetching master instructions: ' . $e->getMessage() );
 				$aistma_master_instructions = '';


### PR DESCRIPTION
Fixes #116: Exception class catch was using wrong namespace.

## Problem
Line 825 was catching  which in this namespace context doesn't match the global  class, causing exceptions to not be properly caught.

## Solution
Changed to properly catch  - the global Exception class.

Closes #116