### PR TITLE
Fix: Correct log_event() call signature

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1748,7 +1748,8 @@ class AISTMA_Admin {
 
 			// Log the event
 			if ( class_exists( __NAMESPACE__ . '\\AISTMA_Gateway_Logger' ) ) {
-				AISTMA_Gateway_Logger::log_event( 'aistma_weekly_schedule_enabled', array(
+				AISTMA_Gateway_Logger::log_event( array(
+					'event_type' => 'aistma_weekly_schedule_enabled',
 					'user_id' => $user_id,
 					'prompt_id' => $prompt_id,
 				) );
@@ -2017,7 +2018,8 @@ class AISTMA_Admin {
 
 			// Log the escape event
 			if ( class_exists( __NAMESPACE__ . '\\AISTMA_Gateway_Logger' ) ) {
-				AISTMA_Gateway_Logger::log_event( 'aistma_wizard_closed_without_generating', array(
+				AISTMA_Gateway_Logger::log_event( array(
+					'event_type' => 'aistma_wizard_closed_without_generating',
 					'user_id' => $user_id,
 					'timestamp' => current_time( 'mysql' ),
 				) );

--- a/ai-story-maker.php
+++ b/ai-story-maker.php
@@ -166,7 +166,8 @@ function aistma_process_weekly_generations() {
 				
 				// Log event
 				if ( class_exists( 'exedotcom\\aistorymaker\\AISTMA_Gateway_Logger' ) ) {
-					exedotcom\aistorymaker\AISTMA_Gateway_Logger::log_event( 'aistma_weekly_generated', array(
+					exedotcom\aistorymaker\AISTMA_Gateway_Logger::log_event( array(
+						'event_type' => 'aistma_weekly_generated',
 						'user_id' => $user_id,
 						'post_id' => $post_id,
 						'prompt_id' => $prompt_id,


### PR DESCRIPTION
Fixes #115: Three log_event() calls were using wrong signature.

## Problem  
log_event() expects single array argument: 
But was being called with: 

## Solution
Updated 3 calls in:
- ai-story-maker.php: aistma_weekly_generated
- admin/class-aistma-admin.php: aistma_weekly_schedule_enabled
- admin/class-aistma-admin.php: aistma_wizard_closed_without_generating

All now pass single array with 'event_type' key.

Closes #115