### PR TITLE
Fix remaining log_event() signature issues

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1921,7 +1921,6 @@ class AISTMA_Admin {
 				AISTMA_Gateway_Logger::log_event( array(
 					'event_type' => 'aistma_wizard_closed_without_generating',
 					'user_id' => $user_id,
-					'timestamp' => current_time( 'mysql' ),
 				) );
 			}
 


### PR DESCRIPTION
## Summary
Fixed 3 additional instances where `log_event()` was being called with incorrect signature.

## Changes
- Update `ai-story-maker.php` line 169-173: Fix weekly generation event logging
- Update `admin/class-aistma-admin.php` line 1772-1776: Fix weekly schedule enabled event
- Update `admin/class-aistma-admin.php` line 2042-2046: Fix wizard closed event and remove unnecessary timestamp parameter

All calls now pass a single array with `event_type` as a key, matching the expected signature in `AISTMA_Gateway_Logger::log_event()`.

## Test plan
- Run plugin and verify no gateway logger warnings
- Check logs for proper event type values
- Verify weekly scheduling and wizard closure events are logged correctly

Fixes #106

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>