### PR TITLE
Fix: Store prompt ID as post meta for later lookup

### DIFF
--- a/includes/class-aistma-story-generator.php
+++ b/includes/class-aistma-story-generator.php
@@ -568,8 +568,11 @@ class AISTMA_Story_Generator {
 		}
 
 		// Store the prompt ID for later lookup in generate_ai_story_for_user()
+		// Note: prompt_id can be numeric (post ID) or string (wizard prompt ID)
 		if ( $post_id && $prompt_id ) {
-			add_post_meta( $post_id, '_aistma_prompt_id', absint( $prompt_id ), true );
+			// Store as-is: numeric IDs stay numeric, string IDs stay string
+			$stored_prompt_id = is_numeric( $prompt_id ) ? absint( $prompt_id ) : sanitize_key( $prompt_id );
+			add_post_meta( $post_id, '_aistma_prompt_id', $stored_prompt_id, true );
 		}
 
 		// Deduct credit after successful post creation
@@ -737,8 +740,11 @@ class AISTMA_Story_Generator {
 		}
 
 		// Store the prompt ID for later lookup in generate_ai_story_for_user()
+		// Note: prompt_id can be numeric (post ID) or string (wizard prompt ID)
 		if ( $post_id && $prompt_id ) {
-			add_post_meta( $post_id, '_aistma_prompt_id', absint( $prompt_id ), true );
+			// Store as-is: numeric IDs stay numeric, string IDs stay string
+			$stored_prompt_id = is_numeric( $prompt_id ) ? absint( $prompt_id ) : sanitize_key( $prompt_id );
+			add_post_meta( $post_id, '_aistma_prompt_id', $stored_prompt_id, true );
 		}
 
 		// Deduct credit after successful post creation (use passed $user_id to support background generation)

--- a/includes/class-aistma-story-generator.php
+++ b/includes/class-aistma-story-generator.php
@@ -545,7 +545,7 @@ class AISTMA_Story_Generator {
 		// Determine post status based on auto_publish setting
 		$auto_publish_value = isset( $prompt['auto_publish'] ) ? $prompt['auto_publish'] : false;
 		$post_status = ( 1 === $auto_publish_value || true === $auto_publish_value ) ? 'publish' : 'draft';
-		
+
 		// Debug logging for auto_publish
 		$this->aistma_log_manager->log( 'debug', 'Master API - Auto publish value: ' . ( $auto_publish_value ? 'true' : 'false' ) . ' (type: ' . gettype( $auto_publish_value ) . '), Post status: ' . $post_status );
 
@@ -565,6 +565,11 @@ class AISTMA_Story_Generator {
 			$error = __( 'Error creating post: ', 'ai-story-maker' ) . $post_id->get_error_message();
 			$this->aistma_log_manager->log( 'error', $error );
 			throw new \RuntimeException( esc_html( $error ) );
+		}
+
+		// Store the prompt ID for later lookup in generate_ai_story_for_user()
+		if ( $post_id && $prompt_id ) {
+			add_post_meta( $post_id, '_aistma_prompt_id', absint( $prompt_id ), true );
 		}
 
 		// Deduct credit after successful post creation
@@ -729,6 +734,11 @@ class AISTMA_Story_Generator {
 			$error = __( 'Error creating post: ', 'ai-story-maker' ) . $post_id->get_error_message();
 			$this->aistma_log_manager->log( 'error', $error );
 			throw new \RuntimeException( esc_html( $error ) );
+		}
+
+		// Store the prompt ID for later lookup in generate_ai_story_for_user()
+		if ( $post_id && $prompt_id ) {
+			add_post_meta( $post_id, '_aistma_prompt_id', absint( $prompt_id ), true );
 		}
 
 		// Deduct credit after successful post creation (use passed $user_id to support background generation)


### PR DESCRIPTION
## Summary
Fixed the meta lookup issue in `generate_ai_story_for_user()` by storing the prompt ID as post meta when stories are created.

## Problem
The `generate_ai_story_for_user()` function tries to find posts by querying for `_aistma_prompt_id` meta, but this meta was never actually being stored when posts were created. This caused the function to always return empty results.

## Solution
- Add `_aistma_prompt_id` post meta storage after successful post creation
- Store in both story generation paths:
  1. Master API path (process_master_api_response)
  2. OpenAI API path (process_openai_response)
- Meta is stored with `absint($prompt_id)` to match the query format

## Test plan
- Create a story via weekly scheduler
- Verify the post has `_aistma_prompt_id` meta stored
- Verify `generate_ai_story_for_user()` can find the created post
- Check that the meta value matches the prompt ID used for generation

Fixes #120

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>