### PR TITLE
Fix: Support string prompt IDs in weekly scheduler

### DIFF
--- a/includes/class-aistma-story-generator.php
+++ b/includes/class-aistma-story-generator.php
@@ -1502,22 +1502,59 @@ class AISTMA_Story_Generator {
 		try {
 			$instance = new self();
 			$user_id = absint( $user_id );
-			$prompt_id = absint( $prompt_id );
 
 			if ( ! $user_id || ! $prompt_id ) {
 				return false;
 			}
 
-			// Get prompt
-			$prompt_post = get_post( $prompt_id );
-			if ( ! $prompt_post || 'aistma_prompt' !== $prompt_post->post_type ) {
-				return false;
-			}
+			// Support both numeric post IDs and string wizard prompt IDs
+			$is_numeric_id = is_numeric( $prompt_id );
+			$prompt_data = null;
 
-			// Get prompt meta
-			$prompt_text = get_post_meta( $prompt_id, '_aistma_prompt_text', true );
-			if ( ! $prompt_text ) {
-				return false;
+			if ( $is_numeric_id ) {
+				// Load from WordPress post
+				$prompt_id = absint( $prompt_id );
+				if ( ! $prompt_id ) {
+					return false;
+				}
+
+				$prompt_post = get_post( $prompt_id );
+				if ( ! $prompt_post || 'aistma_prompt' !== $prompt_post->post_type ) {
+					return false;
+				}
+
+				// Get prompt meta
+				$prompt_text = get_post_meta( $prompt_id, '_aistma_prompt_text', true );
+				if ( ! $prompt_text ) {
+					return false;
+				}
+
+				$prompt_data = array(
+					'text'     => $prompt_text,
+					'category' => get_post_meta( $prompt_id, '_aistma_category', true ),
+				);
+			} else {
+				// Load from wizard prompts in settings
+				$raw_json = get_option( 'aistma_prompts', '{}' );
+				$settings = json_decode( $raw_json, true );
+				$prompts = isset( $settings['prompts'] ) ? $settings['prompts'] : array();
+
+				foreach ( $prompts as $p ) {
+					if ( isset( $p['prompt_id'] ) && $p['prompt_id'] === $prompt_id ) {
+						$prompt_data = array(
+							'text'     => isset( $p['text'] ) ? $p['text'] : '',
+							'category' => isset( $p['category'] ) ? $p['category'] : '',
+						);
+						break;
+					}
+				}
+
+				if ( ! $prompt_data || empty( $prompt_data['text'] ) ) {
+					return false;
+				}
+
+				// Sanitize the string ID
+				$prompt_id = sanitize_key( $prompt_id );
 			}
 
 			// Generate the story
@@ -1529,8 +1566,8 @@ class AISTMA_Story_Generator {
 				$instance->generate_ai_story(
 					$prompt_id,
 					array(
-						'text'       => $prompt_text,
-						'category'   => get_post_meta( $prompt_id, '_aistma_category', true ),
+						'text'       => $prompt_data['text'],
+						'category'   => $prompt_data['category'],
 						'post_type'  => 'post',
 					),
 					$instance->default_settings,

--- a/includes/class-aistma-weekly-scheduler.php
+++ b/includes/class-aistma-weekly-scheduler.php
@@ -57,32 +57,66 @@ class AISTMA_Weekly_Scheduler {
 	 * Get the saved prompt ID for weekly generation.
 	 *
 	 * @param int $user_id The user ID.
-	 * @return int|false The prompt ID, or false if not set.
+	 * @return int|string|false The prompt ID (numeric or string), or false if not set.
 	 */
 	public static function get_weekly_prompt( $user_id ) {
 		$prompt_id = get_user_meta( $user_id, self::META_KEY_WEEKLY_PROMPT_ID, true );
-		return $prompt_id ? absint( $prompt_id ) : false;
+		if ( ! $prompt_id ) {
+			return false;
+		}
+
+		// Return numeric IDs as integers, string IDs as-is
+		return is_numeric( $prompt_id ) ? absint( $prompt_id ) : sanitize_key( $prompt_id );
 	}
 
 	/**
 	 * Enable weekly auto-generation and save the prompt.
 	 *
-	 * @param int $user_id   The user ID.
-	 * @param int $prompt_id The prompt post ID to use for weekly generation.
+	 * @param int    $user_id   The user ID.
+	 * @param mixed  $prompt_id The prompt ID (numeric post ID or string wizard prompt ID).
 	 * @return bool True on success.
 	 */
 	public static function enable_weekly( $user_id, $prompt_id ) {
-		$user_id   = absint( $user_id );
-		$prompt_id = absint( $prompt_id );
+		$user_id = absint( $user_id );
 
 		if ( ! $user_id || ! $prompt_id ) {
 			return false;
 		}
 
-		// Verify the prompt exists
-		$prompt_post = get_post( $prompt_id );
-		if ( ! $prompt_post || 'aistma_prompt' !== $prompt_post->post_type ) {
-			return false;
+		// Support both numeric post IDs and string wizard prompt IDs
+		$is_numeric_id = is_numeric( $prompt_id );
+
+		if ( $is_numeric_id ) {
+			// Numeric ID: verify it's a valid aistma_prompt post
+			$prompt_id = absint( $prompt_id );
+			if ( ! $prompt_id ) {
+				return false;
+			}
+
+			$prompt_post = get_post( $prompt_id );
+			if ( ! $prompt_post || 'aistma_prompt' !== $prompt_post->post_type ) {
+				return false;
+			}
+		} else {
+			// String ID: verify it's a valid wizard prompt in settings
+			$raw_json = get_option( 'aistma_prompts', '{}' );
+			$settings = json_decode( $raw_json, true );
+			$prompts = isset( $settings['prompts'] ) ? $settings['prompts'] : array();
+
+			$prompt_found = false;
+			foreach ( $prompts as $p ) {
+				if ( isset( $p['prompt_id'] ) && $p['prompt_id'] === $prompt_id ) {
+					$prompt_found = true;
+					break;
+				}
+			}
+
+			if ( ! $prompt_found ) {
+				return false;
+			}
+
+			// Sanitize the string ID
+			$prompt_id = sanitize_key( $prompt_id );
 		}
 
 		// Save the prompt ID


### PR DESCRIPTION
## Summary
Extended the weekly scheduler to support both numeric post IDs and string wizard prompt IDs, enabling weekly generation with prompts selected during the activation wizard.

## Problem
The weekly scheduler only worked with numeric WordPress post IDs. When users selected a prompt from the wizard, a string ID (like 'story-adventure') was used, causing `enable_weekly()` to fail silently because `absint()` converted the string to 0.

## Changes
1. **enable_weekly()**: Now accepts both numeric and string prompt IDs
   - Numeric IDs: Verify against aistma_prompt posts (existing behavior)
   - String IDs: Verify against wizard prompts stored in aistma_prompts option

2. **get_weekly_prompt()**: Returns prompt IDs in their original format
   - Numeric IDs returned as integers
   - String IDs returned as sanitized strings (not converted to 0)

3. **generate_ai_story_for_user()**: Loads prompt data from the correct source
   - Numeric IDs: Load from post meta
   - String IDs: Load from wizard prompts in settings
   - Properly stores `_aistma_prompt_id` meta for post lookup

## Test plan
- Enable weekly generation in the activation wizard
- Verify the weekly flag is set for the user
- Verify the selected wizard prompt is saved
- Run the weekly cron event and verify a story is generated
- Verify the generated post has the correct `_aistma_prompt_id` meta
- Test with both wizard prompts and custom post-based prompts

Fixes #104 (enable_weekly() silently broken for wizard prompts)
Fixes #114 (Weekly scheduler silently broken for string prompt IDs)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>