### PR TITLE
Fix: Delete orphaned draft posts when wizard is cancelled

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1742,6 +1742,11 @@ class AISTMA_Admin {
 				wp_send_json_error( array( 'message' => __( 'You do not have permission to delete this post.', 'ai-story-maker' ) ) );
 			}
 
+			// Only delete draft posts (safety check)
+			if ( 'draft' !== $post->post_status ) {
+				wp_send_json_error( array( 'message' => __( 'Only draft posts can be deleted via the wizard.', 'ai-story-maker' ) ) );
+			}
+
 			// Delete the draft post
 			wp_delete_post( $post_id, true );
 

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -99,6 +99,7 @@ class AISTMA_Admin {
 		add_action( 'admin_head-edit.php', array( $this, 'aistma_add_posts_page_button' ) );
 		add_action( 'wp_ajax_aistma_wizard_generate', array( $this, 'aistma_wizard_generate' ) );
 		add_action( 'wp_ajax_aistma_wizard_save', array( $this, 'aistma_wizard_save' ) );
+		add_action( 'wp_ajax_aistma_wizard_cancel', array( $this, 'aistma_wizard_cancel' ) );
 		add_action( 'wp_ajax_aistma_wizard_dismiss', array( $this, 'aistma_wizard_dismiss' ) );
 		add_action( 'wp_ajax_aistma_confirm_weekly', array( $this, 'aistma_confirm_weekly' ) );
 		add_action( 'wp_ajax_aistma_submit_rating', array( $this, 'aistma_submit_rating' ) );
@@ -171,6 +172,7 @@ class AISTMA_Admin {
 				'showWizard' => AISTMA_Activation_Wizard::maybe_show_wizard() ? '1' : '0',
 				'generateNonce' => wp_create_nonce( 'aistma_wizard_generate_nonce' ),
 				'saveNonce' => wp_create_nonce( 'aistma_wizard_save_nonce' ),
+				'cancelNonce' => wp_create_nonce( 'aistma_wizard_cancel_nonce' ),
 				'dismissNonce' => wp_create_nonce( 'aistma_wizard_dismiss_nonce' ),
 				'weeklyNonce' => wp_create_nonce( 'aistma_confirm_weekly_nonce' ),
 				'startupCreditsNonce' => wp_create_nonce( 'aistma_ensure_startup_credits_nonce' ),
@@ -1708,6 +1710,48 @@ class AISTMA_Admin {
 		} catch ( \Throwable $e ) {
 			$this->aistma_log_manager->log( 'error', 'Wizard save error: ' . $e->getMessage() );
 			wp_send_json_error( array( 'message' => __( 'An error occurred while saving.', 'ai-story-maker' ) ) );
+		}
+	}
+
+	/**
+	 * AJAX handler for canceling the wizard (deletes draft post).
+	 *
+	 * @return void
+	 */
+	public function aistma_wizard_cancel() {
+		// Check nonce
+		if ( ! check_ajax_referer( 'aistma_wizard_cancel_nonce', 'nonce', false ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'ai-story-maker' ) ) );
+		}
+
+		// Check capabilities
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => __( 'You do not have permission to perform this action.', 'ai-story-maker' ) ) );
+		}
+
+		try {
+			$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+			if ( ! $post_id ) {
+				wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'ai-story-maker' ) ) );
+			}
+
+			// Verify the post belongs to the current user
+			$post = get_post( $post_id );
+			if ( ! $post || $post->post_author != get_current_user_id() ) {
+				wp_send_json_error( array( 'message' => __( 'You do not have permission to delete this post.', 'ai-story-maker' ) ) );
+			}
+
+			// Delete the draft post
+			wp_delete_post( $post_id, true );
+
+			$this->aistma_log_manager->log( 'info', 'Draft post ' . $post_id . ' deleted by user ' . get_current_user_id() );
+
+			wp_send_json_success( array( 'message' => __( 'Draft post deleted.', 'ai-story-maker' ) ) );
+
+		} catch ( \Throwable $e ) {
+			$this->aistma_log_manager->log( 'error', 'Wizard cancel error: ' . $e->getMessage() );
+			wp_send_json_error( array( 'message' => __( 'An error occurred while deleting the draft.', 'ai-story-maker' ) ) );
 		}
 	}
 

--- a/admin/js/activation-wizard.js
+++ b/admin/js/activation-wizard.js
@@ -556,6 +556,26 @@
 		 * Close the preview modal
 		 */
 		close: function () {
+			const self = this;
+
+			// Delete the draft post if it exists
+			if (this.postData && this.postData.post_id) {
+				$.ajax({
+					url: ajaxurl,
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'aistma_wizard_cancel',
+						nonce: aistmaWizardL10n.cancelNonce || '',
+						post_id: this.postData.post_id,
+					},
+					error: function () {
+						// Log error but don't block the modal close
+						console.error('Failed to delete draft post.');
+					},
+				});
+			}
+
 			this.$modal.fadeOut(200);
 		},
 	};


### PR DESCRIPTION
## Summary
Implemented cleanup of draft posts when users cancel the activation wizard, preventing orphaned draft posts from accumulating in the database.

## Problem
When users generated a story preview in the activation wizard and then cancelled before saving, the draft post remained in the database as an orphaned draft. This cluttered the posts list and wasted database storage.

## Solution
1. Added new AJAX handler `aistma_wizard_cancel()` to delete draft posts
2. Modified preview modal's `close()` method to call the delete AJAX action
3. Verify post ownership before deletion to prevent unauthorized deletions
4. Log all deletion events for debugging

## Changes
- **admin/class-aistma-admin.php**:
  - Register `wp_ajax_aistma_wizard_cancel` action
  - Implement `aistma_wizard_cancel()` handler with security checks
  - Add `cancelNonce` to localized script data

- **admin/js/activation-wizard.js**:
  - Update preview modal's `close()` method to delete draft via AJAX
  - Gracefully handle deletion errors (don't block modal close)

## Test plan
- Open activation wizard and select a prompt
- View the generated preview
- Click Cancel/Close without saving
- Verify the draft post is deleted (check Posts page)
- Check logs for deletion confirmation
- Test that preview still works normally when saved

## Security
- User must be logged in and have `edit_posts` capability
- Post ownership verified before deletion
- Nonce validation on all AJAX calls

Fixes #105

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>