### PR TITLE
Fix: Enhance .gitignore to exclude non-plugin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,30 @@ package-lock.json
 # Build artifacts
 dist/
 build/
+*.zip
+*.bak
+
+# Development/system directories
+.claude/
+.clawhub/
+.openclaw/
+.openclaw-cli-images/
+svn/
+market-hive/
+
+# Documentation/config files (local development only)
+CLAUDE.md
+BOOTSTRAP.md
+HEARTBEAT.md
+IDENTITY.md
+SOUL.md
+TOOLS.md
+USER.md
+AGENTS.md
+
+# Bot scripts
+whiskey_discord_bot.py
+whiskey_discord_monitor.py
 
 # OS files
 Thumbs.db


### PR DESCRIPTION
## Summary
Updated .gitignore to prevent non-plugin files from being accidentally committed, reducing repo bloat and preventing contributor confusion.

## Problem
The repository was cluttered with development-only files and directories that don't belong in a WordPress plugin distribution:
- Development frameworks (.claude/, .openclaw/, .clawhub/)
- System/config files (CLAUDE.md, BOOTSTRAP.md, etc.)
- Bot scripts (whiskey_discord_bot.py, etc.)
- External projects (svn/, market-hive/)
- Build artifacts (*.zip, *.bak files)

## Solution
Enhanced .gitignore with comprehensive entries for all non-plugin files and directories that should never be committed.

## Impact
- Cleaner repository with focused plugin code only
- Prevents accidental commits of development-only files
- Better experience for external contributors

Fixes #113

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>