### PR TITLE
Feature: Make attribution domain and name configurable

### DIFF
--- a/admin/class-aistma-settings-page.php
+++ b/admin/class-aistma-settings-page.php
@@ -141,6 +141,12 @@ class AISTMA_Settings_Page {
 			case 'aistma_show_exedotcom_attribution':
 				update_option( 'aistma_show_exedotcom_attribution', $setting_value ? 1 : 0 );
 				break;
+			case 'aistma_author_name':
+				update_option( 'aistma_author_name', sanitize_text_field( $setting_value ) );
+				break;
+			case 'aistma_author_url':
+				update_option( 'aistma_author_url', esc_url_raw( $setting_value ) );
+				break;
 			default:
 				wp_send_json_error( [ 'message' => __( 'Unknown setting.', 'ai-story-maker' ) ] );
 				wp_die();

--- a/admin/templates/settings-template.php
+++ b/admin/templates/settings-template.php
@@ -80,10 +80,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				<strong><?php esc_html_e( 'Show "Created by AI Story Maker" attribution', 'ai-story-maker' ); ?></strong>
 				<div class="checkbox-description">
-					<?php esc_html_e( 'Support our work by showing a small attribution link to Exedotcom.ca. Helps us continue developing AI Story Maker.', 'ai-story-maker' ); ?>
+					<?php esc_html_e( 'Show an attribution link to your company/website. Helps users know who maintains the plugin.', 'ai-story-maker' ); ?>
 
 			</div>
 		</label>
+		<div class="setting-label" style="margin-left: 20px;">
+			<label for="aistma_author_name">
+				<h5><?php esc_html_e( 'Attribution Company Name', 'ai-story-maker' ); ?></h5>
+				<input type="text" id="aistma_author_name" data-setting="aistma_author_name" placeholder="Exedotcom.ca" value="<?php echo esc_attr( get_option( 'aistma_author_name', 'Exedotcom.ca' ) ); ?>" />
+				<p class="description"><?php esc_html_e( 'The name of the company/author shown in the attribution link (default: Exedotcom.ca)', 'ai-story-maker' ); ?></p>
+			</label>
+		</div>
+		<div class="setting-label" style="margin-left: 20px;">
+			<label for="aistma_author_url">
+				<h5><?php esc_html_e( 'Attribution URL', 'ai-story-maker' ); ?></h5>
+				<input type="url" id="aistma_author_url" data-setting="aistma_author_url" placeholder="https://exedotcom.ca" value="<?php echo esc_attr( get_option( 'aistma_author_url', 'https://exedotcom.ca' ) ); ?>" />
+				<p class="description"><?php esc_html_e( 'The URL linked in the attribution (default: https://exedotcom.ca)', 'ai-story-maker' ); ?></p>
+			</label>
+		</div>
 <hr>
 		<div class="setting-label">
 			<h4><?php esc_html_e( 'Log Retention (Days)', 'ai-story-maker' ); ?></h4>

--- a/public/templates/aistma-post-template.php
+++ b/public/templates/aistma-post-template.php
@@ -146,9 +146,14 @@ wp_enqueue_script(
 );
 ?>
 <footer class="ai-story-maker-footer">
-	<?php if ( get_option( 'aistma_show_exedotcom_attribution', 0 ) ) : ?>
+	<?php
+	$show_attribution = get_option( 'aistma_show_exedotcom_attribution', 0 );
+	$author_url = get_option( 'aistma_author_url', 'https://exedotcom.ca' );
+	$author_name = get_option( 'aistma_author_name', 'Exedotcom.ca' );
+	?>
+	<?php if ( $show_attribution ) : ?>
 	<p>
-		This story is created by AI Story Maker, a plugin by <a href="https://exedotcom.ca" title="Exedotcom" rel="nofollow" style="color: inherit;">Exedotcom.ca</a>
+		This story is created by AI Story Maker, a plugin by <a href="<?php echo esc_url( $author_url ); ?>" title="<?php echo esc_attr( $author_name ); ?>" rel="nofollow" style="color: inherit;"><?php echo esc_html( $author_name ); ?></a>
 	</p>
 	<?php endif; ?>
 </footer>

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,6 +24,8 @@ $options = array(
 	'aistma_unsplash_api_secret',
 	'aistma_generate_story_cron',
 	'aistma_show_exedotcom_attribution',
+	'aistma_author_name',
+	'aistma_author_url',
 	'aistma_widget_activity_days',
 	'aistma_widget_recent_posts_limit',
 	'aistma_widget_hide_empty_columns',


### PR DESCRIPTION
Allow users to customize the attribution link and text displayed in generated posts instead of hardcoding Exedotcom.ca. Users can now set their own company name and URL in settings.