### PR TITLE
Feature: Support keywords in prompts

### DIFF
--- a/admin/class-aistma-prompt-editor.php
+++ b/admin/class-aistma-prompt-editor.php
@@ -135,6 +135,11 @@ class AISTMA_Prompt_Editor {
 						$data['prompts'][ $index ]['category'] = sanitize_text_field( $prompt['category'] );
 					}
 
+					// Sanitize keywords field
+					if ( isset( $prompt['keywords'] ) ) {
+						$data['prompts'][ $index ]['keywords'] = sanitize_text_field( $prompt['keywords'] );
+					}
+
 					// Sanitize numeric fields
 					if ( isset( $prompt['photos'] ) ) {
 						$data['prompts'][ $index ]['photos'] = absint( $prompt['photos'] );

--- a/admin/templates/prompt-editor-template.php
+++ b/admin/templates/prompt-editor-template.php
@@ -33,6 +33,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<th width="10%">
 						<a href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=category' ) ); ?>" target="_blank"><?php esc_html_e( 'Category', 'ai-story-maker' ); ?></a>
 					</th>
+					<th width="12%">
+						<?php esc_html_e( 'Keywords', 'ai-story-maker' ); ?>
+					</th>
 					<th width="5%">
 						<?php esc_html_e( 'Images', 'ai-story-maker' ); ?>
 					</th>
@@ -55,6 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<?php endforeach; ?>
 							</select>
 						</td>
+						<td contenteditable="true" class="editable" data-field="keywords" title="<?php esc_attr_e( 'Comma-separated keywords to include in the article', 'ai-story-maker' ); ?>"><?php echo esc_html( $prompt['keywords'] ?? '' ); ?></td>
 						<td contenteditable="true" data-field="photos">
 							<select>
 								<option value="0" <?php selected( $prompt['photos'] ?? '', '0' ); ?>>0</option>

--- a/includes/class-aistma-story-generator.php
+++ b/includes/class-aistma-story-generator.php
@@ -180,6 +180,14 @@ class AISTMA_Story_Generator {
 
 		$the_prompt = $prompt['text'];
 
+		// Add keywords to prompt if provided
+		if ( ! empty( $prompt['keywords'] ) ) {
+			$keywords = sanitize_text_field( $prompt['keywords'] );
+			$the_prompt .= "\n\n" . sprintf(
+				__( 'Important: Make sure to naturally include these keywords throughout the article: %s', 'ai-story-maker' ),
+				$keywords
+			);
+		}
 
 		// Credits route through the master API the same way a subscription does.
 		$subscription_info = $this->get_subscription_info();


### PR DESCRIPTION
Allow users to specify keywords that should be included in generated articles to improve SEO and ensure important terms are covered naturally in the content.