### PR TITLE
Improve no credits error message

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1376,7 +1376,7 @@ class AISTMA_Admin {
 				$openai_api_key = get_option( 'aistma_openai_api_key' );
 				if ( empty( $openai_api_key ) ) {
 					wp_send_json_error( array(
-						'message' => __( 'You have no credits remaining. Please upgrade your plan or purchase credits to generate stories.', 'ai-story-maker' ),
+						'message' => __( 'no credit left, pick a subscription plan from the next screen', 'ai-story-maker' ),
 						'redirect_url' => admin_url( 'admin.php?page=aistma-settings&tab=ai_writer' )
 					) );
 				}


### PR DESCRIPTION
## Summary
- Update the error message shown when users have no credits remaining
- Changed from "You have no credits remaining..." to "no credit left, pick a subscription plan from the next screen"
- Provides clearer, more concise messaging to guide users to the subscription/plans tab

## Test plan
- [ ] Set user credits to 0
- [ ] Try to generate a story via the wizard
- [ ] Verify alert shows: "no credit left, pick a subscription plan from the next screen"
- [ ] Verify clicking OK redirects to Settings → Accounts (ai_writer) tab
- [ ] Verify story generation works normally when user has credits

🤖 Generated with [Claude Code](https://claude.com/claude-code)