### PR TITLE
HOTFIX: Fix syntax error in class-aistma-admin.php

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1370,7 +1370,7 @@ class AISTMA_Admin {
 			</script>
 			<?php
 		}
-	}
+
 	public function aistma_wizard_generate() {
 		// Check nonce
 		if ( ! check_ajax_referer( 'aistma_wizard_generate_nonce', 'nonce', false ) ) {


### PR DESCRIPTION
## Critical Fix

Fix parse error on line 1374 in admin/class-aistma-admin.php - extra closing brace was prematurely closing the AISTMA_Admin class.

**Error:** Parse error: syntax error, unexpected token 'public', expecting end of file

**Fix:** Removed stray closing brace on line 1373

This is blocking UAT deployment and must be merged immediately.

🤖 Generated with Claude Code