### PR TITLE
Fix: Reopen PHP block after closing ?> on line 430

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -428,6 +428,7 @@ class AISTMA_Admin {
 			)
 		);
 		?>
+<?php
 	}
 
 	/**


### PR DESCRIPTION
## Problem
The `?>` on line 430 closes the PHP block without reopening it, causing all subsequent methods (including `init_social_media_bulk_actions`) to be treated as plain text instead of PHP code. This results in fatal error:

```
Call to undefined method exedotcom\aistorymaker\AISTMA_Admin::init_social_media_bulk_actions()
```

## Solution
Added `<?php` after the `?>` to reopen the PHP block and allow subsequent method declarations to be parsed as PHP code.

## Impact
- Fixes critical fatal error on WordPress admin
- Allows social media bulk actions and all other subsequent methods to be properly recognized
- Restores v2.3.0 functionality on UAT and production