### PR TITLE
Feature: Auto API key issuance, wizard enrollment, and production-ready fixes

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1932,6 +1932,14 @@ class AISTMA_Admin {
 		$response_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 === $response_code || 201 === $response_code ) {
 			$this->aistma_log_manager->log( 'info', 'User auto-enrolled in free package for domain: ' . $domain );
+
+			// Store the gateway API key returned by enrollment so story generation can authenticate.
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			if ( ! empty( $body['api_key'] ) && empty( get_option( 'aistma_gateway_api_key' ) ) ) {
+				update_option( 'aistma_gateway_api_key', sanitize_text_field( $body['api_key'] ) );
+				$this->aistma_log_manager->log( 'info', 'Gateway API key stored for domain: ' . $domain );
+			}
+
 			return true;
 		} else {
 			$this->aistma_log_manager->log( 'warning', 'Gateway returned status ' . $response_code . ' for free package auto-enrollment.' );

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1353,8 +1353,8 @@ class AISTMA_Admin {
 		include AISTMA_PATH . 'admin/templates/weekly-confirmation-modal-template.php';
 
 		// Rating modal only on post-editing pages, not on the dashboard
-		global $hook_suffix;
-		if ( 'index.php' !== $hook_suffix ) {
+		$screen = get_current_screen();
+		if ( ! $screen || 'dashboard' !== $screen->id ) {
 			include AISTMA_PATH . 'admin/templates/rating-modal-template.php';
 
 			$user_id = get_current_user_id();
@@ -1391,9 +1391,11 @@ class AISTMA_Admin {
 				wp_send_json_error( array( 'message' => __( 'No prompt selected.', 'ai-story-maker' ) ) );
 			}
 
-			// Auto-enroll user in free package when they commit to generating a story
-			// This grants free tier credits without requiring a separate startup credits process
-			$this->auto_enroll_free_package( get_option( 'admin_email' ) );
+			// Auto-enroll in free package only when not yet enrolled (no gateway key = not enrolled).
+			// Guarded to avoid an outbound HTTP call on every story generation.
+			if ( empty( get_option( 'aistma_gateway_api_key' ) ) ) {
+				$this->auto_enroll_free_package( get_option( 'admin_email' ) );
+			}
 
 			// Check credits, but allow fallback if user has their own OpenAI API key
 			if ( ! AISTMA_Credits_Manager::has_credits( $user_id, 1 ) ) {

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1908,7 +1908,7 @@ class AISTMA_Admin {
 	private function auto_enroll_free_package( $admin_email ) {
 		$domain = sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ?? wp_parse_url( home_url(), PHP_URL_HOST ) ) );
 		$gateway_url = defined( 'AISTMA_MASTER_API' ) ? AISTMA_MASTER_API : 'https://www.storymakerplugin.com';
-		$endpoint = trailingslashit( $gateway_url ) . 'wp-json/exaig/v1/auto-enroll-free';
+		$endpoint = trailingslashit( $gateway_url ) . 'wp-json/exaig/v1/wizard-enroll-free';
 
 		$body = array(
 			'domain' => $domain,

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -125,7 +125,7 @@ class AISTMA_Admin {
 		$load_rating = false;
 
 		// Load wizard and rating modal on posts page and plugin pages
-		if ( 'edit.php' === $hook_suffix || 'post.php' === $hook_suffix || 'post-new.php' === $hook_suffix ) {
+		if ( in_array( $hook_suffix, [ 'edit.php', 'post.php', 'post-new.php', 'index.php' ], true ) ) {
 			$load_wizard = true;
 			$load_rating = true;
 		}

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1363,6 +1363,7 @@ class AISTMA_Admin {
 			</script>
 			<?php
 		}
+	}
 
 	public function aistma_wizard_generate() {
 		// Check nonce

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1883,39 +1883,11 @@ class AISTMA_Admin {
 	 * @return void
 	 */
 	public function aistma_ensure_startup_credits() {
-		// Check nonce
-		if ( ! check_ajax_referer( 'aistma_ensure_startup_credits_nonce', 'nonce', false ) ) {
-			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'ai-story-maker' ) ) );
-		}
-
-		// Check capabilities
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			wp_send_json_error( array( 'message' => __( 'You do not have permission to perform this action.', 'ai-story-maker' ) ) );
-		}
-
-		try {
-			$user_id = get_current_user_id();
-			$existing_balance = AISTMA_Credits_Manager::get_user_credits( $user_id );
-
-			// Only grant credits if user doesn't have any yet
-			if ( 0 === $existing_balance ) {
-				$startup_credits = absint( get_option( 'aistma_startup_credit_amount', 5 ) );
-				AISTMA_Credits_Manager::add_credits( $user_id, $startup_credits, 'Wizard view - startup grant' );
-				$this->aistma_log_manager->log( 'info', sprintf( 'User %d granted %d startup credits on wizard view.', $user_id, $startup_credits ) );
-
-				// Create startup credits account in gateway with admin email
-				$this->create_startup_credits_account( get_option( 'admin_email' ) );
-			}
-
-			wp_send_json_success( array(
-				'message' => __( 'Credits ensured.', 'ai-story-maker' ),
-				'credits' => AISTMA_Credits_Manager::get_user_credits( $user_id ),
-			) );
-
-		} catch ( \Throwable $e ) {
-			$this->aistma_log_manager->log( 'error', 'Ensure startup credits error: ' . $e->getMessage() );
-			wp_send_json_error( array( 'message' => __( 'An error occurred.', 'ai-story-maker' ) ) );
-		}
+		// DEPRECATED: Startup credits are now granted via auto_enroll_free_package
+		// This handler is kept for backward compatibility but no longer used
+		wp_send_json_success( array(
+			'message' => __( 'Credits ensured.', 'ai-story-maker' ),
+		) );
 	}
 
 	/**

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -124,10 +124,15 @@ class AISTMA_Admin {
 		$load_wizard = false;
 		$load_rating = false;
 
-		// Load wizard and rating modal on posts page and plugin pages
-		if ( in_array( $hook_suffix, [ 'edit.php', 'post.php', 'post-new.php', 'index.php' ], true ) ) {
+		// Load wizard and rating modal on posts pages
+		if ( in_array( $hook_suffix, [ 'edit.php', 'post.php', 'post-new.php' ], true ) ) {
 			$load_wizard = true;
 			$load_rating = true;
+		}
+
+		// Load wizard on dashboard (for widget button) but not the rating modal
+		if ( 'index.php' === $hook_suffix ) {
+			$load_wizard = true;
 		}
 
 		// Load wizard on plugin settings pages
@@ -1347,21 +1352,23 @@ class AISTMA_Admin {
 		// Render weekly confirmation modal template
 		include AISTMA_PATH . 'admin/templates/weekly-confirmation-modal-template.php';
 
-		// Render rating modal template
-		include AISTMA_PATH . 'admin/templates/rating-modal-template.php';
+		// Rating modal only on post-editing pages, not on the dashboard
+		global $hook_suffix;
+		if ( 'index.php' !== $hook_suffix ) {
+			include AISTMA_PATH . 'admin/templates/rating-modal-template.php';
 
-		// Conditionally show rating modal if user qualifies
-		$user_id = get_current_user_id();
-		if ( AISTMA_Rating_Request::should_show_rating( $user_id ) ) {
-			?>
-			<script type="text/javascript">
-				jQuery(document).ready(function () {
-					if (typeof AistmaRating !== 'undefined') {
-						AistmaRating.show();
-					}
-				});
-			</script>
-			<?php
+			$user_id = get_current_user_id();
+			if ( AISTMA_Rating_Request::should_show_rating( $user_id ) ) {
+				?>
+				<script type="text/javascript">
+					jQuery(document).ready(function () {
+						if (typeof AistmaRating !== 'undefined') {
+							AistmaRating.show();
+						}
+					});
+				</script>
+				<?php
+			}
 		}
 	}
 

--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1383,6 +1383,10 @@ class AISTMA_Admin {
 				wp_send_json_error( array( 'message' => __( 'No prompt selected.', 'ai-story-maker' ) ) );
 			}
 
+			// Auto-enroll user in free package when they commit to generating a story
+			// This grants free tier credits without requiring a separate startup credits process
+			$this->auto_enroll_free_package( get_option( 'admin_email' ) );
+
 			// Check credits, but allow fallback if user has their own OpenAI API key
 			if ( ! AISTMA_Credits_Manager::has_credits( $user_id, 1 ) ) {
 				$openai_api_key = get_option( 'aistma_openai_api_key' );
@@ -1911,6 +1915,47 @@ class AISTMA_Admin {
 		} catch ( \Throwable $e ) {
 			$this->aistma_log_manager->log( 'error', 'Ensure startup credits error: ' . $e->getMessage() );
 			wp_send_json_error( array( 'message' => __( 'An error occurred.', 'ai-story-maker' ) ) );
+		}
+	}
+
+	/**
+	 * Auto-enroll user in free package when they commit to generating a story.
+	 * Replaces the separate startup credits process.
+	 *
+	 * @param string $admin_email The admin email address.
+	 * @return bool True if enrolled, false otherwise.
+	 */
+	private function auto_enroll_free_package( $admin_email ) {
+		$domain = sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ?? wp_parse_url( home_url(), PHP_URL_HOST ) ) );
+		$gateway_url = defined( 'AISTMA_MASTER_API' ) ? AISTMA_MASTER_API : 'https://www.storymakerplugin.com';
+		$endpoint = trailingslashit( $gateway_url ) . 'wp-json/exaig/v1/auto-enroll-free';
+
+		$body = array(
+			'domain' => $domain,
+			'admin_email' => sanitize_email( $admin_email ),
+		);
+
+		$args = array(
+			'method' => 'POST',
+			'body' => wp_json_encode( $body ),
+			'headers' => array( 'Content-Type' => 'application/json' ),
+			'timeout' => 10,
+		);
+
+		$response = wp_remote_post( $endpoint, $args );
+
+		if ( is_wp_error( $response ) ) {
+			$this->aistma_log_manager->log( 'error', 'Failed to auto-enroll in free package: ' . $response->get_error_message() );
+			return false;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 === $response_code || 201 === $response_code ) {
+			$this->aistma_log_manager->log( 'info', 'User auto-enrolled in free package for domain: ' . $domain );
+			return true;
+		} else {
+			$this->aistma_log_manager->log( 'warning', 'Gateway returned status ' . $response_code . ' for free package auto-enrollment.' );
+			return false;
 		}
 	}
 

--- a/admin/class-aistma-settings-page.php
+++ b/admin/class-aistma-settings-page.php
@@ -98,6 +98,11 @@ class AISTMA_Settings_Page {
 		// Validate and update specific settings
 		switch ( $setting_name ) {
 			case 'aistma_openai_api_key':
+				// Skip save if the submitted value is still the masked placeholder.
+				if ( strpos( $setting_value, '*' ) === 0 ) {
+					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
+					wp_die();
+				}
 				if ( ! AISTMA_API_Keys::aistma_validate_aistma_openai_api_key( sanitize_text_field( $setting_value ) ) ) {
 					wp_send_json_error( [ 'message' => __( 'Invalid OpenAI API key.', 'ai-story-maker' ) ] );
 					$this->aistma_log_manager->log( 'error', ' Invalid OpenAI API key.' );
@@ -106,12 +111,24 @@ class AISTMA_Settings_Page {
 				update_option( 'aistma_openai_api_key', sanitize_text_field( $setting_value ) );
 				break;
 			case 'aistma_unsplash_api_key':
+				if ( strpos( $setting_value, '*' ) === 0 ) {
+					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
+					wp_die();
+				}
 				update_option( 'aistma_unsplash_api_key', sanitize_text_field( $setting_value ) );
 				break;
 			case 'aistma_unsplash_api_secret':
+				if ( strpos( $setting_value, '*' ) === 0 ) {
+					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
+					wp_die();
+				}
 				update_option( 'aistma_unsplash_api_secret', sanitize_text_field( $setting_value ) );
 				break;
 			case 'aistma_gateway_api_key':
+				if ( strpos( $setting_value, '*' ) === 0 ) {
+					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
+					wp_die();
+				}
 				update_option( 'aistma_gateway_api_key', sanitize_text_field( $setting_value ) );
 				break;
 			case 'aistma_clear_log_cron':

--- a/admin/class-aistma-settings-page.php
+++ b/admin/class-aistma-settings-page.php
@@ -99,7 +99,7 @@ class AISTMA_Settings_Page {
 		switch ( $setting_name ) {
 			case 'aistma_openai_api_key':
 				// Skip save if the submitted value is still the masked placeholder.
-				if ( strpos( $setting_value, '*' ) === 0 ) {
+				if ( str_contains( $setting_value, '***' ) ) {
 					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
 					wp_die();
 				}
@@ -111,21 +111,21 @@ class AISTMA_Settings_Page {
 				update_option( 'aistma_openai_api_key', sanitize_text_field( $setting_value ) );
 				break;
 			case 'aistma_unsplash_api_key':
-				if ( strpos( $setting_value, '*' ) === 0 ) {
+				if ( str_contains( $setting_value, '***' ) ) {
 					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
 					wp_die();
 				}
 				update_option( 'aistma_unsplash_api_key', sanitize_text_field( $setting_value ) );
 				break;
 			case 'aistma_unsplash_api_secret':
-				if ( strpos( $setting_value, '*' ) === 0 ) {
+				if ( str_contains( $setting_value, '***' ) ) {
 					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
 					wp_die();
 				}
 				update_option( 'aistma_unsplash_api_secret', sanitize_text_field( $setting_value ) );
 				break;
 			case 'aistma_gateway_api_key':
-				if ( strpos( $setting_value, '*' ) === 0 ) {
+				if ( str_contains( $setting_value, '***' ) ) {
 					wp_send_json_success( [ 'message' => __( 'No change detected.', 'ai-story-maker' ) ] );
 					wp_die();
 				}

--- a/admin/js/activation-wizard.js
+++ b/admin/js/activation-wizard.js
@@ -575,6 +575,9 @@
 		},
 	};
 
+	// Expose globally so external scripts (e.g. dashboard widget) can call AistmaWizard.show()
+	window.AistmaWizard = AistmaWizard;
+
 	/**
 	 * Initialize on document ready
 	 */

--- a/admin/js/activation-wizard.js
+++ b/admin/js/activation-wizard.js
@@ -131,6 +131,13 @@
 				return;
 			}
 
+			// Initialize startup credits only when user commits to generating (selecting a prompt)
+			// This ensures enrollment only happens if user doesn't cancel the wizard
+			if (!sessionStorage.getItem('aistma_startup_credits_initialized')) {
+				this.initializeStartupCredits();
+				sessionStorage.setItem('aistma_startup_credits_initialized', '1');
+			}
+
 			// Show loading state
 			this.$loading.show();
 
@@ -245,11 +252,6 @@
 		show: function () {
 			// Mark as shown today BEFORE displaying (prevents showing again today)
 			this.markShownToday();
-			// Initialize startup credits only once when wizard is shown (not on every page load)
-			if (!sessionStorage.getItem('aistma_startup_credits_initialized')) {
-				this.initializeStartupCredits();
-				sessionStorage.setItem('aistma_startup_credits_initialized', '1');
-			}
 			this.$modal.fadeIn(200);
 		},
 	};

--- a/admin/js/activation-wizard.js
+++ b/admin/js/activation-wizard.js
@@ -131,13 +131,6 @@
 				return;
 			}
 
-			// Initialize startup credits only when user commits to generating (selecting a prompt)
-			// This ensures enrollment only happens if user doesn't cancel the wizard
-			if (!sessionStorage.getItem('aistma_startup_credits_initialized')) {
-				this.initializeStartupCredits();
-				sessionStorage.setItem('aistma_startup_credits_initialized', '1');
-			}
-
 			// Show loading state
 			this.$loading.show();
 

--- a/admin/templates/subscriptions-template.php
+++ b/admin/templates/subscriptions-template.php
@@ -23,13 +23,15 @@ if ( ! isset( $active_tab ) ) {
  * @param string $key The raw API key.
  * @return string Masked key, or empty string if key is empty.
  */
-function aistma_mask_api_key( $key ) {
-	if ( empty( $key ) ) {
-		return '';
+if ( ! function_exists( 'aistma_mask_api_key' ) ) {
+	function aistma_mask_api_key( $key ) {
+		if ( empty( $key ) ) {
+			return '';
+		}
+		$len  = strlen( $key );
+		$show = max( 1, (int) ceil( $len * 0.1 ) );
+		return str_repeat( '*', $len - $show ) . substr( $key, -$show );
 	}
-	$len  = strlen( $key );
-	$show = max( 1, (int) ceil( $len * 0.1 ) );
-	return str_repeat( '*', $len - $show ) . substr( $key, -$show );
 }
 
 // Get current user email

--- a/admin/templates/subscriptions-template.php
+++ b/admin/templates/subscriptions-template.php
@@ -17,6 +17,21 @@ if ( ! isset( $active_tab ) ) {
 	$active_tab = 'subscribe';
 }
 
+/**
+ * Returns a masked version of an API key: asterisks for the first 90%, plain text for the last 10%.
+ *
+ * @param string $key The raw API key.
+ * @return string Masked key, or empty string if key is empty.
+ */
+function aistma_mask_api_key( $key ) {
+	if ( empty( $key ) ) {
+		return '';
+	}
+	$len  = strlen( $key );
+	$show = max( 1, (int) ceil( $len * 0.1 ) );
+	return str_repeat( '*', $len - $show ) . substr( $key, -$show );
+}
+
 // Get current user email
 $current_user = wp_get_current_user();
 $current_user_email = $current_user->user_email;
@@ -401,22 +416,22 @@ document.addEventListener('DOMContentLoaded', function() {
 	<label for="aistma_openai_api_key">
 		<?php esc_html_e( 'OpenAI', 'ai-story-maker' ); ?> <a href="https://platform.openai.com/" target="_blank"><?php esc_html_e( 'API', 'ai-story-maker' ); ?></a> <?php esc_html_e( 'Key:', 'ai-story-maker' ); ?>
 	</label>
-	<input type="text" id="aistma_openai_api_key" data-setting="aistma_openai_api_key" value="<?php echo esc_attr( get_option( 'aistma_openai_api_key' ) ); ?>">
+	<input type="text" id="aistma_openai_api_key" data-setting="aistma_openai_api_key" value="<?php echo esc_attr( aistma_mask_api_key( get_option( 'aistma_openai_api_key' ) ) ); ?>" autocomplete="off">
 
 	<label for="aistma_unsplash_api_key">
 		<?php esc_html_e( 'Unsplash', 'ai-story-maker' ); ?> <a href="https://unsplash.com/developers" target="_blank"><?php esc_html_e( 'API Key and Secret', 'ai-story-maker' ); ?></a>:
 	</label>
 	<div class="inline-fields">
 		<label for="aistma_unsplash_api_key"><?php esc_html_e( 'Key:', 'ai-story-maker' ); ?></label>
-		<input type="text" id="aistma_unsplash_api_key" data-setting="aistma_unsplash_api_key" value="<?php echo esc_attr( get_option( 'aistma_unsplash_api_key' ) ); ?>">
+		<input type="text" id="aistma_unsplash_api_key" data-setting="aistma_unsplash_api_key" value="<?php echo esc_attr( aistma_mask_api_key( get_option( 'aistma_unsplash_api_key' ) ) ); ?>" autocomplete="off">
 		<label for="aistma_unsplash_api_secret"><?php esc_html_e( 'Secret:', 'ai-story-maker' ); ?></label>
-		<input type="text" id="aistma_unsplash_api_secret" data-setting="aistma_unsplash_api_secret" value="<?php echo esc_attr( get_option( 'aistma_unsplash_api_secret' ) ); ?>">
+		<input type="text" id="aistma_unsplash_api_secret" data-setting="aistma_unsplash_api_secret" value="<?php echo esc_attr( aistma_mask_api_key( get_option( 'aistma_unsplash_api_secret' ) ) ); ?>" autocomplete="off">
 	</div>
 
 	<label for="aistma_gateway_api_key">
 		<?php esc_html_e( 'ExeDotCom hosted service auth key:', 'ai-story-maker' ); ?>
 	</label>
-	<input type="password" id="aistma_gateway_api_key" data-setting="aistma_gateway_api_key" value="<?php echo esc_attr( get_option( 'aistma_gateway_api_key' ) ); ?>" autocomplete="off">
+	<input type="text" id="aistma_gateway_api_key" data-setting="aistma_gateway_api_key" value="<?php echo esc_attr( aistma_mask_api_key( get_option( 'aistma_gateway_api_key' ) ) ); ?>" autocomplete="off">
 	<p class="description">
 		<?php esc_html_e( 'Advanced: only required when ExeDotCom provides a managed-service auth key for protected gateway calls.', 'ai-story-maker' ); ?>
 	</p>

--- a/admin/widgets/wizard-action-widget.php
+++ b/admin/widgets/wizard-action-widget.php
@@ -47,43 +47,43 @@ class AISTMA_Wizard_Action_Widget {
 		</div>
 
 		<script type="text/javascript">
-			(function() {
-				'use strict';
+			document.addEventListener('DOMContentLoaded', function() {
+				const btn = document.getElementById('aistma-widget-open-wizard');
+				if (!btn) {
+					console.warn('aistma-widget-open-wizard button not found');
+					return;
+				}
 
-				function openWizardFromWidget() {
-					// Wait for jQuery to be available
-					if (typeof jQuery === 'undefined') {
-						setTimeout(openWizardFromWidget, 50);
-						return;
+				btn.addEventListener('click', function(e) {
+					e.preventDefault();
+					console.log('Widget button clicked');
+
+					// Ensure jQuery and AistmaWizard are available
+					function showWizard() {
+						if (typeof jQuery === 'undefined') {
+							console.warn('jQuery not available yet');
+							setTimeout(showWizard, 100);
+							return;
+						}
+
+						if (typeof AistmaWizard === 'undefined') {
+							console.warn('AistmaWizard not available yet');
+							setTimeout(showWizard, 100);
+							return;
+						}
+
+						if (typeof AistmaWizard.show !== 'function') {
+							console.error('AistmaWizard.show is not a function');
+							return;
+						}
+
+						console.log('Calling AistmaWizard.show()');
+						AistmaWizard.show();
 					}
 
-					const $ = jQuery;
-					const btn = $('#aistma-widget-open-wizard');
-					if (!btn.length) return;
-
-					btn.on('click', function(e) {
-						e.preventDefault();
-
-						// Use AistmaWizard.show() to properly initialize the wizard
-						if (typeof AistmaWizard !== 'undefined' && AistmaWizard.show) {
-							AistmaWizard.show();
-						} else {
-							// Fallback if AistmaWizard is not available
-							const modal = $('#aistma-wizard-modal');
-							if (modal.length) {
-								modal.fadeIn(200);
-							}
-						}
-					});
-				}
-
-				// Wait for DOM and jQuery to be ready
-				if (document.readyState === 'loading') {
-					document.addEventListener('DOMContentLoaded', openWizardFromWidget);
-				} else {
-					openWizardFromWidget();
-				}
-			})();
+					showWizard();
+				});
+			});
 		</script>
 		<?php
 	}

--- a/admin/widgets/wizard-action-widget.php
+++ b/admin/widgets/wizard-action-widget.php
@@ -65,6 +65,8 @@ class AISTMA_Wizard_Action_Widget {
 						}
 						if (++attempts < 20) {
 							setTimeout(showWizard, 100);
+						} else {
+							console.warn('AistmaWizard: timed out waiting for wizard script to load.');
 						}
 					}
 

--- a/admin/widgets/wizard-action-widget.php
+++ b/admin/widgets/wizard-action-widget.php
@@ -47,40 +47,43 @@ class AISTMA_Wizard_Action_Widget {
 		</div>
 
 		<script type="text/javascript">
-			(function($) {
+			(function() {
 				'use strict';
-				
+
 				function openWizardFromWidget() {
+					// Wait for jQuery to be available
+					if (typeof jQuery === 'undefined') {
+						setTimeout(openWizardFromWidget, 50);
+						return;
+					}
+
+					const $ = jQuery;
 					const btn = $('#aistma-widget-open-wizard');
 					if (!btn.length) return;
-					
+
 					btn.on('click', function(e) {
 						e.preventDefault();
-						
-						const modal = $('#aistma-wizard-modal');
-						if (modal.length) {
-							// Reset wizard state for fresh start
-							modal.find('.aistma-prompt-card').removeClass('selected');
-							modal.find('#aistma-wizard-dont-show').prop('checked', false);
-							
-							// Show modal
-							modal.fadeIn(200);
-							
-							// Log widget action
-							if (typeof AistmaWizard !== 'undefined') {
-								AistmaWizard.selectedPromptId = null;
+
+						// Use AistmaWizard.show() to properly initialize the wizard
+						if (typeof AistmaWizard !== 'undefined' && AistmaWizard.show) {
+							AistmaWizard.show();
+						} else {
+							// Fallback if AistmaWizard is not available
+							const modal = $('#aistma-wizard-modal');
+							if (modal.length) {
+								modal.fadeIn(200);
 							}
 						}
 					});
 				}
-				
-				// Wait for jQuery and DOM to be ready
+
+				// Wait for DOM and jQuery to be ready
 				if (document.readyState === 'loading') {
 					document.addEventListener('DOMContentLoaded', openWizardFromWidget);
 				} else {
 					openWizardFromWidget();
 				}
-			})(jQuery);
+			})();
 		</script>
 		<?php
 	}

--- a/admin/widgets/wizard-action-widget.php
+++ b/admin/widgets/wizard-action-widget.php
@@ -56,29 +56,16 @@ class AISTMA_Wizard_Action_Widget {
 
 				btn.addEventListener('click', function(e) {
 					e.preventDefault();
-					console.log('Widget button clicked');
 
-					// Ensure jQuery and AistmaWizard are available
+					var attempts = 0;
 					function showWizard() {
-						if (typeof jQuery === 'undefined') {
-							console.warn('jQuery not available yet');
+						if (typeof AistmaWizard !== 'undefined' && typeof AistmaWizard.show === 'function') {
+							AistmaWizard.show();
+							return;
+						}
+						if (++attempts < 20) {
 							setTimeout(showWizard, 100);
-							return;
 						}
-
-						if (typeof AistmaWizard === 'undefined') {
-							console.warn('AistmaWizard not available yet');
-							setTimeout(showWizard, 100);
-							return;
-						}
-
-						if (typeof AistmaWizard.show !== 'function') {
-							console.error('AistmaWizard.show is not a function');
-							return;
-						}
-
-						console.log('Calling AistmaWizard.show()');
-						AistmaWizard.show();
 					}
 
 					showWizard();

--- a/includes/class-aistma-story-generator.php
+++ b/includes/class-aistma-story-generator.php
@@ -1560,6 +1560,9 @@ class AISTMA_Story_Generator {
 				'next_billing_date' => $data['next_billing_date'] ?? '',
 				'user_email' => $data['user_email'] ?? '',
 			);
+			if ( ! empty( $data['client_api_key'] ) && empty( get_option( 'aistma_gateway_api_key' ) ) ) {
+				update_option( 'aistma_gateway_api_key', sanitize_text_field( $data['client_api_key'] ) );
+			}
 			return $this->subscription_status;
 		}
 		if ( isset( $data['valid'] ) && $data['valid'] ) {
@@ -1575,6 +1578,12 @@ class AISTMA_Story_Generator {
 				'next_billing_date' => $data['next_billing_date'] ?? '',
 				'authenticated' => ! empty( $data['authenticated'] ),
 			);
+
+			// Store the gateway API key so subsequent authenticated calls (story generation) succeed.
+			if ( ! empty( $data['client_api_key'] ) && empty( get_option( 'aistma_gateway_api_key' ) ) ) {
+				update_option( 'aistma_gateway_api_key', sanitize_text_field( $data['client_api_key'] ) );
+				$this->aistma_log_manager->log( 'info', 'Gateway API key stored from subscription verification for domain: ' . $domain );
+			}
 		} else {
 			$this->aistma_log_manager->log( 'info', 'No active subscription found for domain: ' . $domain . ', message: ' . ( $data['message'] ?? 'No message' ) );
 			$this->subscription_status = array(


### PR DESCRIPTION
## Summary

- **API key masking**: Settings page shows only the last 10% of API keys; save guard prevents overwriting real keys with masked placeholders
- **Parse error fix**: Missing closing brace in `aistma_render_wizard_modals()` that caused a fatal
- **Dashboard wizard button**: `AistmaWizard` exposed as `window.AistmaWizard` so the dashboard widget button can call it; rating modal excluded from dashboard to prevent `fadeIn` crash; wizard JS now loads on `index.php`
- **Auto gateway key storage**: After successful free enrollment, `api_key` returned by `/wizard-enroll-free` is saved to `aistma_gateway_api_key` option (only if not already set)
- **Paid plan key storage**: After `/verify-subscription` returns a valid subscription, `client_api_key` is saved — covers paid plan users who never go through wizard enrollment
- **Wizard enrollment endpoint**: Changed from `/auto-enroll-free` to `/wizard-enroll-free` to use the proper Stripe + local order path

## Test plan

- [ ] Dashboard "Create Story Now" button opens the wizard
- [ ] Click a wizard prompt → story generates, Free order appears on gateway
- [ ] Settings page API keys show masked values
- [ ] Save a new API key → saves correctly; submit unchanged masked value → no change
- [ ] Paid plan user: subscription check automatically saves gateway key for subsequent story generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)