### PR TITLE
fix: trigger free-tier enrollment when subscription invalid, not just when API key missing

### DIFF
--- a/admin/class-aistma-admin.php
+++ b/admin/class-aistma-admin.php
@@ -1391,23 +1391,6 @@ class AISTMA_Admin {
 				wp_send_json_error( array( 'message' => __( 'No prompt selected.', 'ai-story-maker' ) ) );
 			}
 
-			// Auto-enroll in free package only when not yet enrolled (no gateway key = not enrolled).
-			// Guarded to avoid an outbound HTTP call on every story generation.
-			if ( empty( get_option( 'aistma_gateway_api_key' ) ) ) {
-				$this->auto_enroll_free_package( get_option( 'admin_email' ) );
-			}
-
-			// Check credits, but allow fallback if user has their own OpenAI API key
-			if ( ! AISTMA_Credits_Manager::has_credits( $user_id, 1 ) ) {
-				$openai_api_key = get_option( 'aistma_openai_api_key' );
-				if ( empty( $openai_api_key ) ) {
-					wp_send_json_error( array(
-						'message' => __( 'no credit left, pick a subscription plan from the next screen', 'ai-story-maker' ),
-						'redirect_url' => admin_url( 'admin.php?page=aistma-settings&tab=ai_writer' )
-					) );
-				}
-			}
-
 			// Get the selected prompt from wizard defaults
 			$prompts = AISTMA_Activation_Wizard::get_default_prompts();
 			$selected_prompt = null;
@@ -1422,10 +1405,18 @@ class AISTMA_Admin {
 				wp_send_json_error( array( 'message' => __( 'Invalid prompt selected.', 'ai-story-maker' ) ) );
 			}
 
-			// Get subscription and API key info for story generation
+			// Get subscription status. If invalid, attempt free-tier enrollment and re-check.
+			// This handles both: no API key yet, and API key exists but domain has no subscription in gateway DB.
 			$story_generator = new AISTMA_Story_Generator();
 			$subscription_info = $story_generator->get_subscription_info();
 			$has_valid_subscription = $subscription_info['valid'];
+
+			if ( ! $has_valid_subscription ) {
+				$this->auto_enroll_free_package( get_option( 'admin_email' ) );
+				$subscription_info = $story_generator->get_subscription_info();
+				$has_valid_subscription = $subscription_info['valid'];
+			}
+
 			$has_local_credits = AISTMA_Credits_Manager::has_credits( $user_id, 1 );
 
 			// Require an OpenAI API key only when the user has neither a subscription nor credits.


### PR DESCRIPTION
## Problem

Clicking a wizard prompt on `edmonton.urbanslices.com` returned **"Story generation temporarily unavailable"**.

Root cause: the enrollment guard only checked `empty(aistma_gateway_api_key)`. A domain can have an API key stored from a previous setup but **no active subscription row in the gateway DB**. In that case enrollment was silently skipped, the gateway returned 403 on the generate-story call, and with no personal OpenAI key as fallback the error was thrown.

Log trail:
```
verify-subscription → {"valid":false,"message":"No subscription found."}
Master API returned HTTP 403, falling back to direct OpenAI call
Story generation temporarily unavailable. Please try again later.
```

## Fix

Remove the API-key guard. Instead:
1. Check subscription status first
2. If invalid → attempt free-tier enrollment via `/wizard-enroll-free`
3. Re-check subscription after enrollment
4. Only then proceed to story generation

This correctly handles both cases: brand-new install (no key) and reinstall/migration (key present, no DB row).

## Test plan

- [ ] Fresh install — wizard prompt generates successfully (enrollment happens, then story runs)
- [ ] Domain with stored API key but no gateway subscription (e.g. `edmonton.urbanslices.com`) — wizard prompt triggers enrollment then generates successfully
- [ ] Domain with valid active subscription — no enrollment call made, generates as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)