### PR TITLE
Release 2.3.3: bump versions and add changelog entry

### DIFF
--- a/ai-story-maker.php
+++ b/ai-story-maker.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Story Maker
  * Plugin URI: https://www.storymakerplugin.com/
  * Description: AI-powered content generator for WordPress — create engaging stories with a single click.
- * Version: 2.3.2
+ * Version: 2.3.3
  * Author: Hayan Mamoun
  * Author URI: https://exedotcom.ca
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 define( 'AISTMA_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AISTMA_URL', plugin_dir_url( __FILE__ ) );
-define( 'AISTMA_VERSION', '2.3.2' );
+define( 'AISTMA_VERSION', '2.3.3' );
 
 
 use exedotcom\aistorymaker\AISTMA_Story_Generator;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, content creation, blog automation, article generation, wordpress ai pl
 Requires at least: 5.8
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.2
+Stable tag: 2.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://www.storymakerplugin.com/
@@ -106,6 +106,9 @@ This plugin makes requests to external services for core functionality:
 4. SEO & Meta panel — generate optimised meta descriptions for your posts with a single click.
 
 == Changelog ==
+
+= 2.3.3 =
+* Maintenance release: republished 2.3.2 content under a new tag to ensure the WP.org plugin directory receives the latest code (the prior tag had been packaged from an outdated working copy).
 
 = 2.3.2 =
 * **NEW: Frontend dashboard widgets as shortcodes** -- the Data Overview, Generation Calendar, and Recent Posts Activity admin widgets can now be embedded on any page via [aistma_data_overview], [aistma_generation_calendar], and [aistma_recent_activity]


### PR DESCRIPTION
Maintenance release to re-publish 2.3.2 content under a fresh WP.org tag. The earlier tags/2.3.2/ on plugins.svn.wordpress.org was packaged from an outdated working copy that reintroduced the deleted credit-ledger files; bumping to 2.3.3 lets us publish the correct code under a clean tag rather than modifying the existing 2.3.2 tag.

- ai-story-maker.php: Version: 2.3.3 + AISTMA_VERSION constant
- readme.txt: Stable tag: 2.3.3 + new 2.3.3 changelog entry