### PR TITLE
docs: document WP 7.0 Abilities API in readme.txt, README.md, and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,33 @@ Whether you're a blogger, marketer, or educator, AI Story Maker helps you build 
 - **Custom Story Scroller** – Display stories dynamically on the frontend.
 - **Auto Model Attribution** – Add a model credit note automatically for transparency.
 - **Logging System** – Monitor and debug AI generations easily.
+- **WP 7.0 AI Agent Ready** – Three named Abilities registered automatically so any WP 7.0 AI workflow can orchestrate story generation, content enhancement, and scheduling.
+
+== WordPress 7.0 AI Agent Integration ==
+
+AI Story Maker registers three Abilities with the WordPress 7.0 Ability Registry, making your content engine orchestratable by any WP 7.0 AI workflow or agent plugin.
+
+| Ability | What it does |
+|---|---|
+| `ai-story-maker/generate-story` | Generate a new story using your configured prompts |
+| `ai-story-maker/enhance-content` | Improve or rewrite existing post content with AI |
+| `ai-story-maker/schedule-stories` | Enable or disable weekly auto-generation for a user |
+
+**Quick example** — invoke from any WP 7.0 workflow:
+
+```php
+$result = wp_invoke_ability( 'ai-story-maker/generate-story', [
+    'prompt_id' => 'my-prompt-id',
+] );
+
+if ( $result['success'] ) {
+    // $result['post_id'] and $result['post_url'] are ready to use
+}
+```
+
+Credits are deducted the same way as every other generation method — no separate billing. On WordPress 6.x the plugin functions normally; the Abilities registration is silently skipped.
+
+→ Full documentation: [docs/abilities-api.md](docs/abilities-api.md)
 
 == Installation ==
 
@@ -172,6 +199,12 @@ Yes, edit the "General Instructions" field to control structure, tone, and style
 
 = Can I disable automatic generation? =
 Yes, set "Generate New Stories Every" to `0` to disable scheduled stories.
+
+= Can I use the AI Story Maker Abilities to generate posts without installing or activating the plugin? =
+No. Abilities are registered locally by the plugin when it loads on your WordPress site. If the plugin is not installed and active, its abilities do not exist in the registry and cannot be invoked. There is no remote service that exposes them independently.
+
+= Will using Abilities to generate stories deduct my credits? =
+Yes, exactly the same as every other generation method. Ability-invoked generation goes through the same gateway path as the manual button, the activation wizard, and the weekly scheduler. Credits are deducted server-side by the gateway. If your plan has no credits remaining, the ability returns an error and no post is created.
 
 == Changelog ==
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -459,6 +459,16 @@ Coming soon:
 - Well-documented code
 - Extensible architecture
 
+### Q: Can I use AI Story Maker Abilities to generate posts without installing or activating the plugin?
+**A:** No. The Abilities API is a WordPress 7.0 feature that works locally — abilities are registered by the plugin when it loads on your site. If the plugin is not installed and activated, its abilities do not exist in the registry and cannot be invoked by any agent or workflow.
+
+There is no remote service or cloud endpoint that exposes the abilities independently. The plugin must be present and active on the WordPress site where you want generation to happen.
+
+### Q: When using Abilities to generate stories, will it deduct my credits like regular story generation?
+**A:** Yes. The `generate-story` ability goes through the exact same gateway path as every other generation method — the manual generate button, the activation wizard, and the weekly scheduler all call the same underlying code. Credits are deducted server-side by the gateway regardless of what triggered the generation. There is no separate credit pool or discount for ability-invoked generation.
+
+If your plan has no credits remaining, the ability returns an error and no post is created — same behaviour as any other generation attempt.
+
 ### Q: How do I report bugs or request features?
 **A:** 
 - GitHub Issues: https://github.com/hmamoun/ai-story-maker/issues

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,21 @@ Ideal for bloggers, marketers, coaches, educators, and content creators.
 - Automatic fallback: generate stories using master API when credits are available, no subscription required
 - Clean shortcode and widget setup
 - Multilingual ready
+- **Native WP 7.0 AI agent support** — three Abilities registered automatically for orchestration by any WP 7.0 AI workflow
+
+== WordPress 7.0 AI Agent Integration ==
+
+AI Story Maker is AI agent-ready for WordPress 7.0. Three named Abilities are registered automatically when the plugin is active, making your content engine orchestratable by any WP 7.0 AI workflow:
+
+* **ai-story-maker/generate-story** — Generate a new story using your configured prompts. Pass an optional `prompt_id` to run a single prompt, or omit it to run all active prompts in one batch.
+* **ai-story-maker/enhance-content** — Improve or rewrite a block of existing post content using AI. Pass the post ID, the text to improve, and a plain-English instruction.
+* **ai-story-maker/schedule-stories** — Enable or disable weekly automatic story generation for a user and set which prompt to use.
+
+**Credit usage:** Ability-invoked generation uses the same credit pool as every other generation method — the manual button, the wizard, and the scheduler all go through the same gateway. No separate billing, no extra setup.
+
+**Backwards compatible:** On WordPress 6.x the plugin functions normally. The Abilities registration is silently skipped if `wp_register_ability()` does not exist.
+
+For full developer documentation including input/output schemas, code examples, and recipes, see `docs/abilities-api.md`.
 
 == Installation ==
 1. Upload the plugin folder to `/wp-content/plugins/` or install via the WordPress plugin screen.
@@ -104,6 +119,14 @@ This plugin makes requests to external services for core functionality:
 2. Posts list integration — one-click "Generate AI Stories" button and per-post "AI Story Enhancer" action.
 3. AI Story Enhancer — select any text in your post and choose how to rewrite, expand, or improve it.
 4. SEO & Meta panel — generate optimised meta descriptions for your posts with a single click.
+
+== Frequently Asked Questions ==
+
+= Can I use the AI Story Maker Abilities to generate posts without installing or activating the plugin? =
+No. Abilities are registered locally by the plugin when it loads on your WordPress site. If the plugin is not installed and active, its abilities do not exist in the registry and cannot be invoked. There is no remote service that exposes them independently.
+
+= Will using Abilities to generate stories deduct my credits? =
+Yes, exactly the same as every other generation method. Ability-invoked generation goes through the same gateway path as the manual button, the activation wizard, and the weekly scheduler. Credits are deducted server-side by the gateway. If your plan has no credits remaining, the ability returns an error and no post is created.
 
 == Changelog ==
 


### PR DESCRIPTION
- readme.txt: add 'WordPress 7.0 AI Agent Integration' section, bullet in Developer Friendly features, and two FAQ entries (no-install, credits)
- README.md: matching section with ability table + quick-start code example, same FAQ entries, WP 7.0 bullet in Features list
- docs/FAQ.md: remove Q2 added in error; add credits FAQ entry