### PR TITLE
chore: bump version to 2.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tags: ai, content creation, blog automation, article generation, wordpress ai pl
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.0
+Stable tag: 2.3.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://github.com/hmamoun/ai-story-maker

--- a/ai-story-maker.php
+++ b/ai-story-maker.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Story Maker
  * Plugin URI: https://www.storymakerplugin.com/
  * Description: AI-powered content generator for WordPress — create engaging stories with a single click.
- * Version: 2.3.3
+ * Version: 2.3.4
  * Author: Hayan Mamoun
  * Author URI: https://exedotcom.ca
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 define( 'AISTMA_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AISTMA_URL', plugin_dir_url( __FILE__ ) );
-define( 'AISTMA_VERSION', '2.3.3' );
+define( 'AISTMA_VERSION', '2.3.4' );
 define( 'AISTMA_PRICING_URL', 'https://www.storymakerplugin.com/#pricing' );
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, content creation, blog automation, article generation, wordpress ai pl
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.3
+Stable tag: 2.3.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://www.storymakerplugin.com/
@@ -129,6 +129,11 @@ No. Abilities are registered locally by the plugin when it loads on your WordPre
 Yes, exactly the same as every other generation method. Ability-invoked generation goes through the same gateway path as the manual button, the activation wizard, and the weekly scheduler. Credits are deducted server-side by the gateway. If your plan has no credits remaining, the ability returns an error and no post is created.
 
 == Changelog ==
+
+= 2.3.4 =
+* **NEW: Admin review notice** — after 5 story generations or 7 days of use, administrators see a friendly rating bar. 4–5 stars redirect to WordPress.org; 1–3 stars reveal a feedback form and email the site admin automatically.
+* **NEW: WP 7.0 Abilities API** — registers `generate-story`, `enhance-content`, and `schedule-stories` abilities so AI agents and WP 7.0 workflows can orchestrate the plugin without custom integration code.
+* **NEW: Enriched site-topic prompt** — the activation wizard enriches the site-topic field with the site title, tagline, and SEO meta for higher-quality first prompts.
 
 = 2.3.3 =
 * Maintenance release: republished 2.3.2 content under a new tag to ensure the WP.org plugin directory receives the latest code (the prior tag had been packaged from an outdated working copy).


### PR DESCRIPTION
- ai-story-maker.php: Version header + AISTMA_VERSION constant → 2.3.4
- readme.txt: Stable tag → 2.3.4; add 2.3.4 changelog entry
- README.md: Stable tag → 2.3.4 (was stale at 2.3.0)

2.3.4 includes: WP 7.0 Abilities API, admin review notice with feedback email, and enriched site-topic prompt in the activation wizard.