### PR TITLE
chore: bump version to 2.3.5 and fix deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tags: ai, content creation, blog automation, article generation, wordpress ai pl
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.4
+Stable tag: 2.3.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://github.com/hmamoun/ai-story-maker

--- a/ai-story-maker.php
+++ b/ai-story-maker.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Story Maker
  * Plugin URI: https://www.storymakerplugin.com/
  * Description: AI-powered content generator for WordPress — create engaging stories with a single click.
- * Version: 2.3.4
+ * Version: 2.3.5
  * Author: Hayan Mamoun
  * Author URI: https://exedotcom.ca
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 define( 'AISTMA_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AISTMA_URL', plugin_dir_url( __FILE__ ) );
-define( 'AISTMA_VERSION', '2.3.4' );
+define( 'AISTMA_VERSION', '2.3.5' );
 define( 'AISTMA_PRICING_URL', 'https://www.storymakerplugin.com/#pricing' );
 
 

--- a/deploy-to-wordpress.sh
+++ b/deploy-to-wordpress.sh
@@ -2,33 +2,37 @@
 #
 # deploy-to-wordpress.sh
 # -----------------------
-# Publish the current git `main` of AI Story Maker to the WordPress.org plugin
-# SVN repository: syncs trunk, commits it, and creates a matching version tag.
+# Publish the current git `main` to WordPress.org SVN following the official
+# plugin handbook: https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/
 #
-# The version is read automatically from the plugin header in ai-story-maker.php,
-# so make sure you have already bumped the version (header, AISTMA_VERSION
-# constant, readme.txt "Stable tag" + changelog) and merged it to main BEFORE
-# running this.
+# Official flow (single commit — tag is NEVER touched after creation):
+#   1. svn up
+#   2. Sync git-tracked files → trunk/
+#   3. svn add / svn delete to stage changes in trunk
+#   4. svn cp trunk tags/VERSION   (LOCAL copy — no server round-trip yet)
+#   5. svn ci                      (ONE commit covers trunk + new tag together)
 #
-# Auth: the FIRST time you ever push, run an `svn commit` interactively once in
-# your Terminal so macOS caches your wordpress.org credential in the Keychain.
-# After that this script runs non-interactively.
+# Prerequisites:
+#   - Version bumped in ai-story-maker.php header, AISTMA_VERSION constant,
+#     readme.txt Stable tag + changelog, README.md — all merged to main.
+#   - SVN credentials cached in macOS Keychain (run one interactive svn commit
+#     to seed it, then all subsequent commits work non-interactively).
 #
 # Usage:
-#   ./deploy-to-wordpress.sh            # dry-run preview (no commits)
-#   ./deploy-to-wordpress.sh --push     # actually commit trunk + create the tag
+#   ./deploy-to-wordpress.sh            # dry-run: preview changes, no commits
+#   ./deploy-to-wordpress.sh --push     # commit trunk + tag in one SVN commit
 #
 set -euo pipefail
 
 # ----------------------------------------------------------------------------
-# Configuration — adjust paths only if your local layout changes.
+# Configuration
 # ----------------------------------------------------------------------------
 GIT_DIR="/Users/hayan/Documents/Documents - HALMAMOUN-MBP/repos/plugins/ai-story-maker"
 SVN_DIR="/Users/hayan/Documents/Documents - HALMAMOUN-MBP/repos/projects/ai-story-maker/svn/ai-story-maker"
 SVN_USER="hmamoun"
-MAIN_PLUGIN_FILE="ai-story-maker.php"
+PLUGIN_FILE="ai-story-maker.php"
 
-# Files/dirs that live in git but must NEVER ship to WordPress.org.
+# Files/dirs in git that must NEVER ship to WordPress.org
 EXCLUDES=(
   ".svn" ".git" ".github" ".gitignore" ".eslintrc.cjs" ".phpcs.xml"
   "README.md" "ai_plugins_comparison.md" "eslint.config.js"
@@ -48,55 +52,56 @@ die()  { printf "\033[1;31m[error]\033[0m %s\n" "$*" >&2; exit 1; }
 [[ -d "$SVN_DIR/.svn" ]] || die "svn working copy not found at: $SVN_DIR"
 
 # ----------------------------------------------------------------------------
-# 1. Make sure git main is the source of truth and is clean & up to date.
+# 1. Verify git main is clean and up to date
 # ----------------------------------------------------------------------------
 say "Checking git main is clean and current"
 cd "$GIT_DIR"
 branch=$(git rev-parse --abbrev-ref HEAD)
 [[ "$branch" == "main" ]] || die "You are on '$branch', not 'main'. Checkout main first."
-# Only TRACKED modifications block a deploy — git archive ships tracked files
-# only, so untracked local files (marketing scratch, etc.) can't leak. Warn on
-# them so a genuinely-new-but-uncommitted file doesn't silently miss the release.
+
 if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
   die "git has uncommitted changes to tracked files. Commit or stash first."
 fi
+
 untracked=$(git status --porcelain --untracked-files=normal | grep '^??' || true)
 if [[ -n "$untracked" ]]; then
-  warn "Untracked files present (will NOT ship — only tracked files are exported):"
+  warn "Untracked files present (will NOT ship — git archive exports tracked files only):"
   echo "$untracked" | sed 's/^/    /'
 fi
+
 git fetch origin --quiet
-if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+[[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || \
   die "Local main differs from origin/main. Run 'git pull' first."
-fi
 
 # ----------------------------------------------------------------------------
-# 2. Determine the release version from the plugin header.
+# 2. Read and validate version
 # ----------------------------------------------------------------------------
-VERSION=$(grep -m1 -E "^[[:space:]]*\*[[:space:]]*Version:" "$GIT_DIR/$MAIN_PLUGIN_FILE" \
+VERSION=$(grep -m1 -E "^[[:space:]]*\*[[:space:]]*Version:" "$GIT_DIR/$PLUGIN_FILE" \
             | sed -E 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
-[[ -n "$VERSION" ]] || die "Could not read Version from $MAIN_PLUGIN_FILE header."
+[[ -n "$VERSION" ]] || die "Could not read Version from $PLUGIN_FILE header."
 
-STABLE=$(grep -m1 "Stable tag:" "$GIT_DIR/readme.txt" | sed -E 's/.*Stable tag:[[:space:]]*//' | tr -d '[:space:]')
-[[ "$STABLE" == "$VERSION" ]] || die "Mismatch: header Version=$VERSION but readme Stable tag=$STABLE. Fix in git first."
+STABLE=$(grep -m1 "Stable tag:" "$GIT_DIR/readme.txt" \
+           | sed -E 's/.*Stable tag:[[:space:]]*//' | tr -d '[:space:]')
+[[ "$STABLE" == "$VERSION" ]] || \
+  die "Mismatch: plugin header Version=$VERSION but readme.txt Stable tag=$STABLE. Fix in git first."
 
 say "Releasing version: $VERSION"
 
-# Abort if this tag already exists on the server.
+# Guard: abort if tag already exists — NEVER modify an existing tag
 if svn ls "https://plugins.svn.wordpress.org/ai-story-maker/tags/$VERSION" >/dev/null 2>&1; then
-  die "tags/$VERSION already exists on WordPress.org. Bump the version or pick a new one."
+  die "tags/$VERSION already exists on WordPress.org. A published tag must never be modified. Bump the version."
 fi
 
 # ----------------------------------------------------------------------------
-# 3. Refresh the SVN working copy.
+# 3. svn up — get latest from WordPress.org
 # ----------------------------------------------------------------------------
-say "svn update (pull latest from WordPress.org)"
+say "svn update"
 svn update "$SVN_DIR" --non-interactive
 
 # ----------------------------------------------------------------------------
-# 4. Export git-tracked files only (no untracked junk) and rsync into trunk.
+# 4. Export only git-tracked files into trunk (no untracked junk)
 # ----------------------------------------------------------------------------
-say "Exporting git-tracked files and syncing into trunk"
+say "Syncing git-tracked files into trunk"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 git -C "$GIT_DIR" archive --format=tar HEAD | tar -x -C "$TMP"
@@ -106,14 +111,13 @@ for e in "${EXCLUDES[@]}"; do rsync_excludes+=( --exclude="$e" ); done
 rsync -rc --delete "${rsync_excludes[@]}" "$TMP/" "$SVN_DIR/trunk/"
 
 # ----------------------------------------------------------------------------
-# 5. Stage adds (new files) and deletes (removed files) in trunk.
+# 5. Stage adds and deletes — scoped to trunk/ only
+#    (old tags on macOS show case-sensitivity ! artifacts — never touch those)
 # ----------------------------------------------------------------------------
 say "Staging adds/deletes in trunk"
 cd "$SVN_DIR/trunk"
-# Schedule unversioned files for addition.
 svn add --force . --quiet 2>/dev/null || true
-# Schedule missing files for deletion.
-svn status | awk '/^!/{ $1=""; sub(/^[ \t]+/,""); print }' | while IFS= read -r f; do
+svn status . | awk '/^!/{ $1=""; sub(/^[ \t]+/,""); print }' | while IFS= read -r f; do
   [[ -n "$f" ]] && svn delete --force "$f" >/dev/null 2>&1 || true
 done
 
@@ -121,41 +125,44 @@ say "Pending trunk changes:"
 svn status "$SVN_DIR/trunk" || true
 
 # ----------------------------------------------------------------------------
-# 6. Commit trunk + create the tag (only with --push).
+# 6. (--push only) LOCAL copy trunk → tags/VERSION, then ONE svn commit
+#    Official handbook: svn cp trunk tags/X.X  →  svn ci
+#    This is a single atomic commit — the tag is created clean and never
+#    touched again, which is required for WP.org to generate the zip.
 # ----------------------------------------------------------------------------
 if ! $PUSH; then
-  warn "Dry run complete. Review the changes above."
-  warn "Re-run with --push to commit trunk and create tags/$VERSION."
+  warn "Dry run complete — no commits made."
+  warn "Re-run with --push to release tags/$VERSION."
   exit 0
 fi
 
-say "Committing trunk to WordPress.org"
-svn commit "$SVN_DIR/trunk" \
-  -m "Update trunk to version $VERSION" \
+say "Creating local tag copy: svn cp trunk → tags/$VERSION"
+cd "$SVN_DIR"
+[[ -d "tags/$VERSION" ]] && die "tags/$VERSION already exists locally. Run 'svn update' and check."
+svn cp trunk "tags/$VERSION"
+
+say "Single svn commit: trunk + tags/$VERSION together"
+svn commit \
+  -m "Release version $VERSION" \
   --username "$SVN_USER" --non-interactive
 
-say "Creating tags/$VERSION (server-side copy)"
-svn copy \
-  "https://plugins.svn.wordpress.org/ai-story-maker/trunk" \
-  "https://plugins.svn.wordpress.org/ai-story-maker/tags/$VERSION" \
-  -m "Tagging version $VERSION" \
-  --username "$SVN_USER" --non-interactive
-
-say "svn update (pull the new tag into the working copy)"
+say "svn update (pull new tag into working copy)"
 svn update "$SVN_DIR" --non-interactive >/dev/null
 
 # ----------------------------------------------------------------------------
-# 7. Verify.
+# 7. Verify remote state
 # ----------------------------------------------------------------------------
 say "Verifying remote consistency"
-remote_trunk_stable=$(svn cat "https://plugins.svn.wordpress.org/ai-story-maker/trunk/readme.txt" | grep -m1 "Stable tag:" | sed -E 's/.*Stable tag:[[:space:]]*//' | tr -d '[:space:]')
-remote_tag_ver=$(svn cat "https://plugins.svn.wordpress.org/ai-story-maker/tags/$VERSION/$MAIN_PLUGIN_FILE" | grep -m1 -E "Version:" | sed -E 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
+remote_stable=$(svn cat "https://plugins.svn.wordpress.org/ai-story-maker/trunk/readme.txt" \
+  | grep -m1 "Stable tag:" | sed -E 's/.*Stable tag:[[:space:]]*//' | tr -d '[:space:]')
+remote_tag_ver=$(svn cat "https://plugins.svn.wordpress.org/ai-story-maker/tags/$VERSION/$PLUGIN_FILE" \
+  | grep -m1 -E "^\s*\* Version:" | sed -E 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
 
-printf "  trunk Stable tag : %s\n" "$remote_trunk_stable"
-printf "  tags/%s header  : %s\n" "$VERSION" "$remote_tag_ver"
+printf "  trunk Stable tag    : %s\n" "$remote_stable"
+printf "  tags/%s Version : %s\n" "$VERSION" "$remote_tag_ver"
 
-if [[ "$remote_trunk_stable" == "$VERSION" && "$remote_tag_ver" == "$VERSION" ]]; then
-  say "✅ Released $VERSION to WordPress.org. Update notice will roll out shortly."
+if [[ "$remote_stable" == "$VERSION" && "$remote_tag_ver" == "$VERSION" ]]; then
+  say "✅ Released $VERSION to WordPress.org (single commit, clean tag). Zip will generate within minutes."
 else
-  die "Post-deploy verification mismatch — inspect manually."
+  die "Post-deploy verification mismatch — check SVN manually."
 fi

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, content creation, blog automation, article generation, wordpress ai pl
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.4
+Stable tag: 2.3.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://www.storymakerplugin.com/
@@ -129,6 +129,9 @@ No. Abilities are registered locally by the plugin when it loads on your WordPre
 Yes, exactly the same as every other generation method. Ability-invoked generation goes through the same gateway path as the manual button, the activation wizard, and the weekly scheduler. Credits are deducted server-side by the gateway. If your plan has no credits remaining, the ability returns an error and no post is created.
 
 == Changelog ==
+
+= 2.3.5 =
+* Maintenance release: re-publishes 2.3.4 content under a clean tag to ensure the WP.org plugin directory serves the correct version (the prior tag was modified post-creation, preventing zip generation).
 
 = 2.3.4 =
 * **NEW: Admin review notice** — after 5 story generations or 7 days of use, administrators see a friendly rating bar. 4–5 stars redirect to WordPress.org; 1–3 stars reveal a feedback form and email the site admin automatically.


### PR DESCRIPTION
- Version bump to 2.3.5 (maintenance release — clean tag for WP.org)
- readme.txt: Stable tag 2.3.5 + changelog entry
- README.md: Stable tag 2.3.5
- deploy-to-wordpress.sh: rewritten to follow official WP.org handbook — single svn commit covers trunk + tag together (svn cp trunk tags/X then svn ci), preventing the tag-modification issue that blocked 2.3.4 zip.