### PR TITLE
fix: settings Save button with inline JS

### DIFF
--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -180,78 +180,8 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     }
 
-    // === Settings Save Button ===
-    if (window.aistmaSettings) {
-        const aistmaNonce   = window.aistmaSettings.nonce;
-        const aistmaAjaxUrl = window.aistmaSettings.ajaxUrl;
-
-        function aistmaShowMsg(msg, success) {
-            const el = document.getElementById('aistma-settings-message');
-            if (!el) return;
-            el.textContent = msg;
-            el.style.cssText = 'display:block;padding:8px 12px;margin:10px 0;border-radius:4px;'
-                + (success
-                    ? 'color:#28a745;background:#d4edda;border:1px solid #c3e6cb;'
-                    : 'color:#dc3545;background:#f8d7da;border:1px solid #f5c6cb;');
-            setTimeout(function() { el.style.display = 'none'; }, 4000);
-        }
-
-        function aistmaFieldValue(el) {
-            return el.type === 'checkbox' ? (el.checked ? '1' : '0') : el.value;
-        }
-
-        // Any interaction with a [data-setting] field enables the Save button
-        document.addEventListener('change', function(e) {
-            if (!e.target.hasAttribute('data-setting')) return;
-            const btn = document.getElementById('aistma-save-settings-btn');
-            if (btn) btn.disabled = false;
-        });
-        document.addEventListener('input', function(e) {
-            if (!e.target.hasAttribute('data-setting')) return;
-            const btn = document.getElementById('aistma-save-settings-btn');
-            if (btn) btn.disabled = false;
-        });
-
-        document.addEventListener('click', function(e) {
-            if (e.target.id !== 'aistma-save-settings-btn') return;
-            const btn = e.target;
-            const fields = document.querySelectorAll('[data-setting]');
-            if (!fields.length) return;
-
-            btn.disabled = true;
-            btn.textContent = 'Saving…';
-
-            let done = 0, errors = 0;
-            fields.forEach(function(field) {
-                const fd = new FormData();
-                fd.append('action',          'aistma_save_setting');
-                fd.append('aistma_security', aistmaNonce);
-                fd.append('setting_name',    field.getAttribute('data-setting'));
-                fd.append('setting_value',   aistmaFieldValue(field));
-                fetch(aistmaAjaxUrl, { method: 'POST', body: fd })
-                    .then(function(r) { return r.text(); })
-                    .then(function(text) {
-                        try {
-                            if (!JSON.parse(text).success) errors++;
-                        } catch(e) { errors++; }
-                    })
-                    .catch(function() { errors++; })
-                    .finally(function() {
-                        done++;
-                        if (done < fields.length) return;
-                        btn.textContent = 'Save Settings';
-                        if (errors) {
-                            aistmaShowMsg('Some settings could not be saved.', false);
-                            btn.disabled = false;
-                        } else {
-                            aistmaShowMsg('Settings saved!', true);
-                            btn.disabled = true;
-                        }
-                    });
-            });
-        });
-    }
     });
+// Settings save JS is inlined in settings-template.php and subscriptions-template.php
 
     // check if the button exists before adding the event listener
     if (document.getElementById("aistma-generate-stories-button"))

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -242,16 +242,24 @@ document.addEventListener("DOMContentLoaded", function() {
             method: 'POST',
             body: data
         })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                aistma_show_message(data.data.message, true);
+        .then(response => response.text())
+        .then(text => {
+            let json;
+            try {
+                json = JSON.parse(text);
+            } catch (e) {
+                console.error('aistma settings: non-JSON response', text);
+                aistma_show_message('Server error. Please try again.', false);
+                return;
+            }
+            if (json.success) {
+                aistma_show_message(json.data.message, true);
             } else {
-                aistma_show_message(data.data.message || 'Error saving setting.', false);
+                aistma_show_message((json.data && json.data.message) || 'Error saving setting.', false);
             }
         })
         .catch((error) => {
-            console.error('Settings save error:', error);
+            console.error('aistma settings: fetch error', error);
             aistma_show_message('Network error. Please try again.', false);
         })
         .finally(() => {
@@ -273,10 +281,10 @@ document.addEventListener("DOMContentLoaded", function() {
                 control.addEventListener('change', function() {
                     aistma_save_setting(setting, control.value);
                 });
-            } else if (control.type === 'text') {
+            } else if (control.type === 'text' || control.type === 'url') {
                 control.addEventListener('input', aistma_debounce(function() {
                     aistma_save_setting(setting, control.value);
-            }, 800)); // Increased debounce time for better UX
+            }, 800));
             }
         });
     });

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -181,104 +181,71 @@ document.addEventListener("DOMContentLoaded", function() {
     }
 
     // === Settings Save Button ===
-    const aistmaSettingsMessage = document.getElementById("aistma-settings-message");
-    const aistmaNonce = window.aistmaSettings ? window.aistmaSettings.nonce : '';
-    const aistmaAjaxUrl = window.aistmaSettings ? window.aistmaSettings.ajaxUrl : '';
-    const aistmaSaveBtn = document.getElementById("aistma-save-settings-btn");
+    if (window.aistmaSettings) {
+        const aistmaNonce   = window.aistmaSettings.nonce;
+        const aistmaAjaxUrl = window.aistmaSettings.ajaxUrl;
 
-    function aistma_show_message(msg, success) {
-        if (!aistmaSettingsMessage) return;
-        aistmaSettingsMessage.textContent = msg;
-        aistmaSettingsMessage.style.color = success ? '#28a745' : '#dc3545';
-        aistmaSettingsMessage.style.backgroundColor = success ? '#d4edda' : '#f8d7da';
-        aistmaSettingsMessage.style.border = success ? '1px solid #c3e6cb' : '1px solid #f5c6cb';
-        aistmaSettingsMessage.style.padding = '8px 12px';
-        aistmaSettingsMessage.style.margin = '10px 0';
-        aistmaSettingsMessage.style.borderRadius = '4px';
-        aistmaSettingsMessage.style.display = 'block';
-        setTimeout(() => { aistmaSettingsMessage.style.display = 'none'; }, 4000);
-    }
-
-    function aistmaGetValue(el) {
-        return el.type === 'checkbox' ? (el.checked ? '1' : '0') : el.value;
-    }
-
-    // Snapshot values on load to detect changes
-    const aistmaOriginals = {};
-    document.querySelectorAll('[data-setting]').forEach(function(el) {
-        aistmaOriginals[el.getAttribute('data-setting')] = aistmaGetValue(el);
-    });
-    console.log('[aistma] init — saveBtn:', aistmaSaveBtn, 'fields snapshotted:', Object.keys(aistmaOriginals));
-
-    function aistmaHasChanges() {
-        let changed = false;
-        document.querySelectorAll('[data-setting]').forEach(function(el) {
-            if (aistmaGetValue(el) !== aistmaOriginals[el.getAttribute('data-setting')]) {
-                changed = true;
-            }
-        });
-        return changed;
-    }
-
-    function aistmaUpdateSaveBtn() {
-        const hasChanges = aistmaHasChanges();
-        console.log('[aistma] updateSaveBtn — btn:', aistmaSaveBtn, 'hasChanges:', hasChanges, 'originals:', aistmaOriginals);
-        if (aistmaSaveBtn) aistmaSaveBtn.disabled = !hasChanges;
-    }
-
-    document.querySelectorAll('[data-setting]').forEach(function(el) {
-        el.addEventListener('change', aistmaUpdateSaveBtn);
-        if (el.type === 'text' || el.type === 'url') {
-            el.addEventListener('input', aistmaUpdateSaveBtn);
+        function aistmaShowMsg(msg, success) {
+            const el = document.getElementById('aistma-settings-message');
+            if (!el) return;
+            el.textContent = msg;
+            el.style.cssText = 'display:block;padding:8px 12px;margin:10px 0;border-radius:4px;'
+                + (success
+                    ? 'color:#28a745;background:#d4edda;border:1px solid #c3e6cb;'
+                    : 'color:#dc3545;background:#f8d7da;border:1px solid #f5c6cb;');
+            setTimeout(function() { el.style.display = 'none'; }, 4000);
         }
-    });
 
-    if (aistmaSaveBtn) {
-        aistmaSaveBtn.addEventListener('click', function() {
-            const toSave = [];
-            document.querySelectorAll('[data-setting]').forEach(function(el) {
-                const key = el.getAttribute('data-setting');
-                const val = aistmaGetValue(el);
-                if (val !== aistmaOriginals[key]) toSave.push({ key, val });
-            });
-            if (!toSave.length) return;
+        function aistmaFieldValue(el) {
+            return el.type === 'checkbox' ? (el.checked ? '1' : '0') : el.value;
+        }
 
-            aistmaSaveBtn.disabled = true;
-            aistmaSaveBtn.textContent = 'Saving…';
+        // Any interaction with a [data-setting] field enables the Save button
+        document.addEventListener('change', function(e) {
+            if (!e.target.hasAttribute('data-setting')) return;
+            const btn = document.getElementById('aistma-save-settings-btn');
+            if (btn) btn.disabled = false;
+        });
+        document.addEventListener('input', function(e) {
+            if (!e.target.hasAttribute('data-setting')) return;
+            const btn = document.getElementById('aistma-save-settings-btn');
+            if (btn) btn.disabled = false;
+        });
+
+        document.addEventListener('click', function(e) {
+            if (e.target.id !== 'aistma-save-settings-btn') return;
+            const btn = e.target;
+            const fields = document.querySelectorAll('[data-setting]');
+            if (!fields.length) return;
+
+            btn.disabled = true;
+            btn.textContent = 'Saving…';
 
             let done = 0, errors = 0;
-            toSave.forEach(function(item) {
+            fields.forEach(function(field) {
                 const fd = new FormData();
-                fd.append('action', 'aistma_save_setting');
+                fd.append('action',          'aistma_save_setting');
                 fd.append('aistma_security', aistmaNonce);
-                fd.append('setting_name', item.key);
-                fd.append('setting_value', item.val);
+                fd.append('setting_name',    field.getAttribute('data-setting'));
+                fd.append('setting_value',   aistmaFieldValue(field));
                 fetch(aistmaAjaxUrl, { method: 'POST', body: fd })
-                    .then(r => r.text())
-                    .then(text => {
+                    .then(function(r) { return r.text(); })
+                    .then(function(text) {
                         try {
-                            const json = JSON.parse(text);
-                            if (!json.success) errors++;
-                        } catch(e) {
-                            console.error('aistma settings: non-JSON response', text);
-                            errors++;
-                        }
+                            if (!JSON.parse(text).success) errors++;
+                        } catch(e) { errors++; }
                     })
-                    .catch(() => errors++)
-                    .finally(() => {
+                    .catch(function() { errors++; })
+                    .finally(function() {
                         done++;
-                        if (done === toSave.length) {
-                            aistmaSaveBtn.textContent = 'Save Settings';
-                            if (errors) {
-                                aistma_show_message('Some settings could not be saved.', false);
-                                aistmaSaveBtn.disabled = false;
-                            } else {
-                                aistma_show_message('Settings saved!', true);
-                                document.querySelectorAll('[data-setting]').forEach(function(el) {
-                                    aistmaOriginals[el.getAttribute('data-setting')] = aistmaGetValue(el);
-                                });
-                                aistmaSaveBtn.disabled = true;
-                            }
+                        if (done < fields.length) return;
+                        btn.textContent = 'Save Settings';
+                        if (errors) {
+                            aistmaShowMsg('Some settings could not be saved.', false);
+                            btn.disabled = false;
+                        } else {
+                            aistmaShowMsg('Settings saved!', true);
+                            btn.disabled = true;
                         }
                     });
             });

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -208,6 +208,7 @@ document.addEventListener("DOMContentLoaded", function() {
     document.querySelectorAll('[data-setting]').forEach(function(el) {
         aistmaOriginals[el.getAttribute('data-setting')] = aistmaGetValue(el);
     });
+    console.log('[aistma] init — saveBtn:', aistmaSaveBtn, 'fields snapshotted:', Object.keys(aistmaOriginals));
 
     function aistmaHasChanges() {
         let changed = false;
@@ -220,7 +221,9 @@ document.addEventListener("DOMContentLoaded", function() {
     }
 
     function aistmaUpdateSaveBtn() {
-        if (aistmaSaveBtn) aistmaSaveBtn.disabled = !aistmaHasChanges();
+        const hasChanges = aistmaHasChanges();
+        console.log('[aistma] updateSaveBtn — btn:', aistmaSaveBtn, 'hasChanges:', hasChanges, 'originals:', aistmaOriginals);
+        if (aistmaSaveBtn) aistmaSaveBtn.disabled = !hasChanges;
     }
 
     document.querySelectorAll('[data-setting]').forEach(function(el) {

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -180,113 +180,107 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     }
 
-    // === AI Story Maker Instant Settings Save ===
-        const aistmaSettingsMessage = document.getElementById("aistma-settings-message");
-        const aistmaNonce = window.aistmaSettings ? window.aistmaSettings.nonce : '';
-        const aistmaAjaxUrl = window.aistmaSettings ? window.aistmaSettings.ajaxUrl : '';
+    // === Settings Save Button ===
+    const aistmaSettingsMessage = document.getElementById("aistma-settings-message");
+    const aistmaNonce = window.aistmaSettings ? window.aistmaSettings.nonce : '';
+    const aistmaAjaxUrl = window.aistmaSettings ? window.aistmaSettings.ajaxUrl : '';
+    const aistmaSaveBtn = document.getElementById("aistma-save-settings-btn");
 
-    // Debounce utility
-        function aistma_debounce(func, wait) {
-            let timeout;
-            return function(...args) {
-                clearTimeout(timeout);
-                timeout = setTimeout(() => func.apply(this, args), wait);
-            };
-        }
-
-            // Enhanced message display with animations
-    function aistma_show_message(msg, success = true) {
+    function aistma_show_message(msg, success) {
         if (!aistmaSettingsMessage) return;
-        
         aistmaSettingsMessage.textContent = msg;
         aistmaSettingsMessage.style.color = success ? '#28a745' : '#dc3545';
         aistmaSettingsMessage.style.backgroundColor = success ? '#d4edda' : '#f8d7da';
         aistmaSettingsMessage.style.border = success ? '1px solid #c3e6cb' : '1px solid #f5c6cb';
-        aistmaSettingsMessage.style.margin = '15px 0';
-        aistmaSettingsMessage.style.opacity = '0';
-        aistmaSettingsMessage.style.transform = 'translateY(-10px)';
-        aistmaSettingsMessage.style.transition = 'all 0.3s ease';
-        
-        // Animate in
-        setTimeout(() => {
-            aistmaSettingsMessage.style.opacity = '1';
-            aistmaSettingsMessage.style.transform = 'translateY(0)';
-        }, 10);
-        
-        // Auto-hide after 4 seconds
-        setTimeout(() => {
-            aistmaSettingsMessage.style.opacity = '0';
-            aistmaSettingsMessage.style.transform = 'translateY(-10px)';
-            setTimeout(() => {
-                aistmaSettingsMessage.textContent = '';
-            }, 300);
-        }, 4000);
+        aistmaSettingsMessage.style.padding = '8px 12px';
+        aistmaSettingsMessage.style.margin = '10px 0';
+        aistmaSettingsMessage.style.borderRadius = '4px';
+        aistmaSettingsMessage.style.display = 'block';
+        setTimeout(() => { aistmaSettingsMessage.style.display = 'none'; }, 4000);
     }
 
-            // Enhanced settings saving with loading states
-    function aistma_save_setting(setting, value) {
-        const control = document.querySelector(`[data-setting="${setting}"]`);
-        if (control) {
-            // Add loading state
-            control.style.opacity = '0.6';
-            control.disabled = true;
+    function aistmaGetValue(el) {
+        return el.type === 'checkbox' ? (el.checked ? '1' : '0') : el.value;
+    }
+
+    // Snapshot values on load to detect changes
+    const aistmaOriginals = {};
+    document.querySelectorAll('[data-setting]').forEach(function(el) {
+        aistmaOriginals[el.getAttribute('data-setting')] = aistmaGetValue(el);
+    });
+
+    function aistmaHasChanges() {
+        let changed = false;
+        document.querySelectorAll('[data-setting]').forEach(function(el) {
+            if (aistmaGetValue(el) !== aistmaOriginals[el.getAttribute('data-setting')]) {
+                changed = true;
+            }
+        });
+        return changed;
+    }
+
+    function aistmaUpdateSaveBtn() {
+        if (aistmaSaveBtn) aistmaSaveBtn.disabled = !aistmaHasChanges();
+    }
+
+    document.querySelectorAll('[data-setting]').forEach(function(el) {
+        el.addEventListener('change', aistmaUpdateSaveBtn);
+        if (el.type === 'text' || el.type === 'url') {
+            el.addEventListener('input', aistmaUpdateSaveBtn);
         }
+    });
 
-        const data = new FormData();
-        data.append('action', 'aistma_save_setting');
-        data.append('aistma_security', aistmaNonce);
-        data.append('setting_name', setting);
-        data.append('setting_value', value);
-        
-        fetch(aistmaAjaxUrl, {
-            method: 'POST',
-            body: data
-        })
-        .then(response => response.text())
-        .then(text => {
-            let json;
-            try {
-                json = JSON.parse(text);
-            } catch (e) {
-                console.error('aistma settings: non-JSON response', text);
-                aistma_show_message('Server error. Please try again.', false);
-                return;
-            }
-            if (json.success) {
-                aistma_show_message(json.data.message, true);
-            } else {
-                aistma_show_message((json.data && json.data.message) || 'Error saving setting.', false);
-            }
-        })
-        .catch((error) => {
-            console.error('aistma settings: fetch error', error);
-            aistma_show_message('Network error. Please try again.', false);
-        })
-        .finally(() => {
-            if (control) {
-                control.style.opacity = '1';
-                control.disabled = false;
-            }
+    if (aistmaSaveBtn) {
+        aistmaSaveBtn.addEventListener('click', function() {
+            const toSave = [];
+            document.querySelectorAll('[data-setting]').forEach(function(el) {
+                const key = el.getAttribute('data-setting');
+                const val = aistmaGetValue(el);
+                if (val !== aistmaOriginals[key]) toSave.push({ key, val });
+            });
+            if (!toSave.length) return;
+
+            aistmaSaveBtn.disabled = true;
+            aistmaSaveBtn.textContent = 'Saving…';
+
+            let done = 0, errors = 0;
+            toSave.forEach(function(item) {
+                const fd = new FormData();
+                fd.append('action', 'aistma_save_setting');
+                fd.append('aistma_security', aistmaNonce);
+                fd.append('setting_name', item.key);
+                fd.append('setting_value', item.val);
+                fetch(aistmaAjaxUrl, { method: 'POST', body: fd })
+                    .then(r => r.text())
+                    .then(text => {
+                        try {
+                            const json = JSON.parse(text);
+                            if (!json.success) errors++;
+                        } catch(e) {
+                            console.error('aistma settings: non-JSON response', text);
+                            errors++;
+                        }
+                    })
+                    .catch(() => errors++)
+                    .finally(() => {
+                        done++;
+                        if (done === toSave.length) {
+                            aistmaSaveBtn.textContent = 'Save Settings';
+                            if (errors) {
+                                aistma_show_message('Some settings could not be saved.', false);
+                                aistmaSaveBtn.disabled = false;
+                            } else {
+                                aistma_show_message('Settings saved!', true);
+                                document.querySelectorAll('[data-setting]').forEach(function(el) {
+                                    aistmaOriginals[el.getAttribute('data-setting')] = aistmaGetValue(el);
+                                });
+                                aistmaSaveBtn.disabled = true;
+                            }
+                        }
+                    });
+            });
         });
     }
-
-    // Attach listeners to all controls with data-setting
-        document.querySelectorAll('[data-setting]').forEach(function(control) {
-            const setting = control.getAttribute('data-setting');
-            if (control.type === 'checkbox') {
-                control.addEventListener('change', function() {
-                    aistma_save_setting(setting, control.checked ? 1 : 0);
-                });
-            } else if (control.tagName === 'SELECT') {
-                control.addEventListener('change', function() {
-                    aistma_save_setting(setting, control.value);
-                });
-            } else if (control.type === 'text' || control.type === 'url') {
-                control.addEventListener('input', aistma_debounce(function() {
-                    aistma_save_setting(setting, control.value);
-            }, 800));
-            }
-        });
     });
 
     // check if the button exists before adding the event listener

--- a/admin/templates/settings-template.php
+++ b/admin/templates/settings-template.php
@@ -17,6 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php
 	// Add a nonce for AJAX security
 	$ajax_nonce = wp_create_nonce( 'aistma_save_setting' );
+
+	// Ensure attribution values are set to the correct defaults
+	if ( ! get_option( 'aistma_author_name' ) || get_option( 'aistma_author_name' ) === 'Exedotcom.ca' ) {
+		update_option( 'aistma_author_name', 'Story Maker Plugin' );
+	}
+	if ( ! get_option( 'aistma_author_url' ) || get_option( 'aistma_author_url' ) === 'https://exedotcom.ca' ) {
+		update_option( 'aistma_author_url', 'https://storymakerplugin.com' );
+	}
 	?>
 	<script type="text/javascript">
 		window.aistmaSettings = {
@@ -25,7 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		};
 	</script>
 
-<div id="aistma-settings-message"></div>
+<div id="aistma-settings-message" style="display:none;"></div>
 
 <p><?php esc_html_e( 'Configure the general settings for AI Story Maker. These settings control how the plugin behaves and generates content. For social media publishing settings, visit the Social Media Integration tab.', 'ai-story-maker' ); ?></p>
 
@@ -84,20 +92,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			</div>
 		</label>
-		<div class="setting-label" style="margin-left: 20px;">
-			<label for="aistma_author_name">
-				<h5><?php esc_html_e( 'Attribution Company Name', 'ai-story-maker' ); ?></h5>
-				<input type="text" id="aistma_author_name" data-setting="aistma_author_name" placeholder="Exedotcom.ca" value="<?php echo esc_attr( get_option( 'aistma_author_name', 'Exedotcom.ca' ) ); ?>" />
-				<p class="description"><?php esc_html_e( 'The name of the company/author shown in the attribution link (default: Exedotcom.ca)', 'ai-story-maker' ); ?></p>
-			</label>
-		</div>
-		<div class="setting-label" style="margin-left: 20px;">
-			<label for="aistma_author_url">
-				<h5><?php esc_html_e( 'Attribution URL', 'ai-story-maker' ); ?></h5>
-				<input type="url" id="aistma_author_url" data-setting="aistma_author_url" placeholder="https://exedotcom.ca" value="<?php echo esc_attr( get_option( 'aistma_author_url', 'https://exedotcom.ca' ) ); ?>" />
-				<p class="description"><?php esc_html_e( 'The URL linked in the attribution (default: https://exedotcom.ca)', 'ai-story-maker' ); ?></p>
-			</label>
-		</div>
+		<input type="hidden" id="aistma_author_name" value="<?php echo esc_attr( get_option( 'aistma_author_name', 'Story Maker Plugin' ) ); ?>" />
+		<input type="hidden" id="aistma_author_url" value="<?php echo esc_attr( get_option( 'aistma_author_url', 'https://storymakerplugin.com' ) ); ?>" />
 <hr>
 		<div class="setting-label">
 			<h4><?php esc_html_e( 'Log Retention (Days)', 'ai-story-maker' ); ?></h4>
@@ -119,6 +115,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php endfor; ?>
 			</select>
 		</div>
+	</div>
+
+	<div style="margin-top: 20px;">
+		<button id="aistma-save-settings-btn" class="button button-primary" disabled>
+			<?php esc_html_e( 'Save Settings', 'ai-story-maker' ); ?>
+		</button>
 	</div>
 	<?php // Generation controls moved to a reusable template included globally. ?>
 </div>

--- a/admin/templates/settings-template.php
+++ b/admin/templates/settings-template.php
@@ -124,6 +124,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<?php // Generation controls moved to a reusable template included globally. ?>
 </div>
+<script>
+(function () {
+	var btn     = document.getElementById('aistma-save-settings-btn');
+	var msgEl   = document.getElementById('aistma-settings-message');
+	var nonce   = window.aistmaSettings ? window.aistmaSettings.nonce   : '';
+	var ajaxUrl = window.aistmaSettings ? window.aistmaSettings.ajaxUrl : '';
+
+	function showMsg(msg, ok) {
+		if (!msgEl) return;
+		msgEl.textContent = msg;
+		msgEl.style.cssText = 'display:block;padding:8px 12px;margin:10px 0;border-radius:4px;'
+			+ (ok ? 'color:#28a745;background:#d4edda;border:1px solid #c3e6cb;'
+			      : 'color:#dc3545;background:#f8d7da;border:1px solid #f5c6cb;');
+		setTimeout(function () { msgEl.style.display = 'none'; }, 4000);
+	}
+
+	function fieldVal(el) {
+		return el.type === 'checkbox' ? (el.checked ? '1' : '0') : el.value;
+	}
+
+	// Enable Save button when any field changes
+	document.querySelectorAll('[data-setting]').forEach(function (el) {
+		el.addEventListener('change', function () { btn.disabled = false; });
+		el.addEventListener('input',  function () { btn.disabled = false; });
+	});
+
+	btn.addEventListener('click', function () {
+		var fields = document.querySelectorAll('[data-setting]');
+		btn.disabled = true;
+		btn.textContent = '<?php echo esc_js( __( 'Saving…', 'ai-story-maker' ) ); ?>';
+		var done = 0, errors = 0;
+		fields.forEach(function (field) {
+			var fd = new FormData();
+			fd.append('action',          'aistma_save_setting');
+			fd.append('aistma_security', nonce);
+			fd.append('setting_name',    field.getAttribute('data-setting'));
+			fd.append('setting_value',   fieldVal(field));
+			fetch(ajaxUrl, { method: 'POST', body: fd })
+				.then(function (r) { return r.text(); })
+				.then(function (t) { try { if (!JSON.parse(t).success) errors++; } catch(e) { errors++; } })
+				.catch(function () { errors++; })
+				.finally(function () {
+					done++;
+					if (done < fields.length) return;
+					btn.textContent = '<?php echo esc_js( __( 'Save Settings', 'ai-story-maker' ) ); ?>';
+					if (errors) {
+						showMsg('<?php echo esc_js( __( 'Some settings could not be saved.', 'ai-story-maker' ) ); ?>', false);
+						btn.disabled = false;
+					} else {
+						showMsg('<?php echo esc_js( __( 'Settings saved!', 'ai-story-maker' ) ); ?>', true);
+						btn.disabled = true;
+					}
+				});
+		});
+	});
+}());
+</script>
 
 </div>
 

--- a/admin/templates/subscriptions-template.php
+++ b/admin/templates/subscriptions-template.php
@@ -444,6 +444,58 @@ document.addEventListener('DOMContentLoaded', function() {
 		</button>
 		<div id="aistma-settings-message" style="display:none; margin-top: 10px;"></div>
 	</div>
+<script>
+(function () {
+	var btn     = document.getElementById('aistma-save-settings-btn');
+	var msgEl   = document.getElementById('aistma-settings-message');
+	var nonce   = window.aistmaSettings ? window.aistmaSettings.nonce   : '';
+	var ajaxUrl = window.aistmaSettings ? window.aistmaSettings.ajaxUrl : '';
+
+	function showMsg(msg, ok) {
+		if (!msgEl) return;
+		msgEl.textContent = msg;
+		msgEl.style.cssText = 'display:block;padding:8px 12px;margin:10px 0;border-radius:4px;'
+			+ (ok ? 'color:#28a745;background:#d4edda;border:1px solid #c3e6cb;'
+			      : 'color:#dc3545;background:#f8d7da;border:1px solid #f5c6cb;');
+		setTimeout(function () { msgEl.style.display = 'none'; }, 4000);
+	}
+
+	document.querySelectorAll('[data-setting]').forEach(function (el) {
+		el.addEventListener('change', function () { btn.disabled = false; });
+		el.addEventListener('input',  function () { btn.disabled = false; });
+	});
+
+	btn.addEventListener('click', function () {
+		var fields = document.querySelectorAll('[data-setting]');
+		btn.disabled = true;
+		btn.textContent = '<?php echo esc_js( __( 'Saving…', 'ai-story-maker' ) ); ?>';
+		var done = 0, errors = 0;
+		fields.forEach(function (field) {
+			var fd = new FormData();
+			fd.append('action',          'aistma_save_setting');
+			fd.append('aistma_security', nonce);
+			fd.append('setting_name',    field.getAttribute('data-setting'));
+			fd.append('setting_value',   field.value);
+			fetch(ajaxUrl, { method: 'POST', body: fd })
+				.then(function (r) { return r.text(); })
+				.then(function (t) { try { if (!JSON.parse(t).success) errors++; } catch(e) { errors++; } })
+				.catch(function () { errors++; })
+				.finally(function () {
+					done++;
+					if (done < fields.length) return;
+					btn.textContent = '<?php echo esc_js( __( 'Save Settings', 'ai-story-maker' ) ); ?>';
+					if (errors) {
+						showMsg('<?php echo esc_js( __( 'Some settings could not be saved.', 'ai-story-maker' ) ); ?>', false);
+						btn.disabled = false;
+					} else {
+						showMsg('<?php echo esc_js( __( 'Settings saved!', 'ai-story-maker' ) ); ?>', true);
+						btn.disabled = true;
+					}
+				});
+		});
+	});
+}());
+</script>
 </div>
 </div>
 

--- a/admin/templates/subscriptions-template.php
+++ b/admin/templates/subscriptions-template.php
@@ -437,6 +437,13 @@ document.addEventListener('DOMContentLoaded', function() {
 	<p class="description">
 		<?php esc_html_e( 'Advanced: only required when ExeDotCom provides a managed-service auth key for protected gateway calls.', 'ai-story-maker' ); ?>
 	</p>
+
+	<div style="margin-top: 20px;">
+		<button id="aistma-save-settings-btn" class="button button-primary" disabled>
+			<?php esc_html_e( 'Save Settings', 'ai-story-maker' ); ?>
+		</button>
+		<div id="aistma-settings-message" style="display:none; margin-top: 10px;"></div>
+	</div>
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Removes auto-save (per-field AJAX on change) from all admin tabs
- Adds Save button to Settings and API Keys tabs, disabled by default
- Enables on any field change; saves all `[data-setting]` fields on click
- JS moved inline in each template (runs synchronously, eliminates timing issues with admin.js/DOMContentLoaded)
- Attribution fields hardcoded to "Story Maker Plugin" / https://storymakerplugin.com and hidden

## Test plan
- [ ] Settings tab: change any dropdown or checkbox → Save button enables
- [ ] Click Save Settings → "Settings saved!" message → button re-disables
- [ ] Refresh → values persist
- [ ] API Keys tab: same behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)