### PR TITLE
chore: bump version to 2.3.6

### DIFF
--- a/ai-story-maker.php
+++ b/ai-story-maker.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Story Maker
  * Plugin URI: https://www.storymakerplugin.com/
  * Description: AI-powered content generator for WordPress — create engaging stories with a single click.
- * Version: 2.3.5
+ * Version: 2.3.6
  * Author: Hayan Mamoun
  * Author URI: https://exedotcom.ca
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 define( 'AISTMA_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AISTMA_URL', plugin_dir_url( __FILE__ ) );
-define( 'AISTMA_VERSION', '2.3.5' );
+define( 'AISTMA_VERSION', '2.3.6' );
 define( 'AISTMA_PRICING_URL', 'https://www.storymakerplugin.com/#pricing' );
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, content creation, blog automation, article generation, wordpress ai pl
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.5
+Stable tag: 2.3.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://www.storymakerplugin.com/
@@ -129,6 +129,10 @@ No. Abilities are registered locally by the plugin when it loads on your WordPre
 Yes, exactly the same as every other generation method. Ability-invoked generation goes through the same gateway path as the manual button, the activation wizard, and the weekly scheduler. Credits are deducted server-side by the gateway. If your plan has no credits remaining, the ability returns an error and no post is created.
 
 == Changelog ==
+
+= 2.3.6 =
+* **FIX: Settings page now uses an explicit Save button** — fields no longer auto-save on change; the Save button is disabled until a value is edited, then re-disables after a successful save.
+* **Attribution settings locked for free plan** — both attribution checkboxes are checked and disabled for free-plan users; paid users can toggle them freely.
 
 = 2.3.5 =
 * Maintenance release: re-publishes 2.3.4 content under a clean tag to ensure the WP.org plugin directory serves the correct version (the prior tag was modified post-creation, preventing zip generation).


### PR DESCRIPTION
Version bump for SVN release. Includes save button fix (#206) and attribution plan-lock (#207).